### PR TITLE
Helps 790 add updatable whispers logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "raw-loader": "^4.0.2",
         "ts-loader": "^8.0.14",
         "typescript": "^4.1.3",
-        "vscode": "^1.1.37",
+        "vscode": "^0.9.9",
         "vscode-test": "^1.5.0",
         "webpack": "^5.19.0",
         "webpack-cli": "^4.4.0"
@@ -798,22 +798,26 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/buffer-from": {
@@ -859,10 +863,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001200",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-      "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
-      "dev": true
+      "version": "1.0.30001243",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+      "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
@@ -1070,9 +1078,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.687",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+      "version": "1.3.770",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.770.tgz",
+      "integrity": "sha512-Kyh8DGK1KfEZuYKIHvuOmrKotsKZQ+qBkDIWHciE3QoFkxXB1KzPP+tfLilSHAfxTON0yYMnFCWkQtUOR7g6KQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1145,21 +1153,6 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
       "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
       "dev": true
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "node_modules/es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "dependencies": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -3193,24 +3186,13 @@
       "dev": true
     },
     "node_modules/vscode": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-0.9.9.tgz",
+      "integrity": "sha1-qpoWeCHg0g1AWfoBj9hA2+BSILM=",
+      "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
       "dev": true,
       "dependencies": {
-        "glob": "^7.1.2",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "mocha": "^5.2.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "vscode-test": "^0.4.1"
-      },
-      "bin": {
-        "vscode-install": "bin/install"
-      },
-      "engines": {
-        "node": ">=8.9.3"
+        "typescript": "^1.6.2"
       }
     },
     "node_modules/vscode-test": {
@@ -3228,194 +3210,17 @@
         "node": ">=8.9.3"
       }
     },
-    "node_modules/vscode/node_modules/agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+    "node_modules/vscode/node_modules/typescript": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
+      "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
       "dev": true,
-      "dependencies": {
-        "es6-promisify": "^5.0.0"
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/vscode/node_modules/commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/vscode/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/vscode/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/vscode/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vscode/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vscode/node_modules/he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/vscode/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "dependencies": {
-        "minimist": "0.0.8"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/vscode/node_modules/mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-      "dev": true,
-      "dependencies": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.5",
-        "he": "1.1.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/vscode/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/vscode/node_modules/supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vscode/node_modules/vscode-test": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
-    "node_modules/vscode/node_modules/vscode-test/node_modules/http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/vscode/node_modules/vscode-test/node_modules/https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/watchpack": {
@@ -4407,16 +4212,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "buffer-from": {
@@ -4450,9 +4255,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001200",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
-      "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
+      "version": "1.0.30001243",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+      "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
       "dev": true
     },
     "chainsaw": {
@@ -4626,9 +4431,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.687",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+      "version": "1.3.770",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.770.tgz",
+      "integrity": "sha512-Kyh8DGK1KfEZuYKIHvuOmrKotsKZQ+qBkDIWHciE3QoFkxXB1KzPP+tfLilSHAfxTON0yYMnFCWkQtUOR7g6KQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -4683,21 +4488,6 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
       "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
       "dev": true
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -6315,168 +6105,19 @@
       "dev": true
     },
     "vscode": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-0.9.9.tgz",
+      "integrity": "sha1-qpoWeCHg0g1AWfoBj9hA2+BSILM=",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "mocha": "^5.2.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "vscode-test": "^0.4.1"
+        "typescript": "^1.6.2"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+        "typescript": {
+          "version": "1.8.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
+          "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
           "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "he": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "mocha": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.1",
-            "commander": "2.15.1",
-            "debug": "3.1.0",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.5",
-            "he": "1.1.1",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "supports-color": "5.4.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "vscode-test": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-          "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-          "dev": true,
-          "requires": {
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1"
-          },
-          "dependencies": {
-            "http-proxy-agent": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-              "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-              "dev": true,
-              "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-              }
-            },
-            "https-proxy-agent": {
-              "version": "2.2.4",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-              "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-              "dev": true,
-              "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-              }
-            }
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "raw-loader": "^4.0.2",
     "ts-loader": "^8.0.14",
     "typescript": "^4.1.3",
-    "vscode": "^1.1.37",
+    "vscode": "^0.9.9",
     "vscode-test": "^1.5.0",
     "webpack": "^5.19.0",
     "webpack-cli": "^4.4.0"

--- a/src/templates/src/index.ts.squirrelly
+++ b/src/templates/src/index.ts.squirrelly
@@ -1,15 +1,32 @@
 import {
+{{ @if (it.aptitudes.includes("clipboard")) }}
   clipboard,
+{{ /if }}
+{{ @if (it.aptitudes.includes("filesystem")) }}
   filesystem,
+{{ /if }}
+{{ @if (it.aptitudes.includes("keyboard")) }}
   keyboard,
+{{ /if }}
+{{ @if (it.aptitudes.includes("network")) }}
   network,
+{{ /if }}
+{{ @if (it.aptitudes.includes("ui")) }}
   ui,
+{{ /if }}
   whisper,
+{{ @if (it.aptitudes.includes("window")) }}
   window,
+{{ /if }}
 } from "@oliveai/ldk";
 import {
   Alignment,
+  ButtonSize,
+  ButtonStyle,
+  ChildComponents,
+{{ @if (it.aptitudes.includes("network")) }}
   Components,
+{{ /if }}
   Direction,
   Urgency,
   WhisperComponentType,
@@ -18,7 +35,13 @@ import {
 import { add, format } from "date-fns";
 {{ /if }}
 
-function createIntroWhisper() {
+// Global variable for updating whisper state
+let WHISPER{{it.isTypeScript ? ': whisper.Whisper': ''}};
+
+function createIntroWhisperComponents(
+  newMessage{{it.isTypeScript ? '?: string' : ''}},
+  numClones{{it.isTypeScript ? ': number' : ''}} = 1
+) {
   const divider{{it.isTypeScript ? ': whisper.Divider' : ''}} = {
     type: WhisperComponentType.Divider,
   };
@@ -160,39 +183,112 @@ function createIntroWhisper() {
     },
   };
 
-  whisper.create({
-    components: [
-      introMessage,
-      divider,
-      collapseBox,
-      divider,
-      boxHeader,
-      box,
-      divider,
-      exampleComponentsHeading,
-      textInput,
-      email,
-      password,
-      telephone,
-      button,
-      link,
-      checkbox,
-      pair,
-      numberInput,
-      select,
-      radioBtn,
-    ],
+  // Showing how to use whisper.update
+  const updatableComponentsHeading{{it.isTypeScript ? ': whisper.Markdown' : ''}} = {
+    type: WhisperComponentType.Markdown,
+    body: "# Updatable Whisper Components",
+  };
+  const updatableMessage{{it.isTypeScript ? ': whisper.Message' : ''}} = {
+    type: WhisperComponentType.Message,
+    header: "This is a component hooked up to Updatable Whisper logic",
+    body: newMessage || "Type in the field below to update this line of text",
+    style: Urgency.Success,
+  };
+  const updatableMessageInput{{it.isTypeScript ? ': whisper.TextInput' : ''}} = {
+    type: WhisperComponentType.TextInput,
+    label: "New Text Input",
+    onChange: (_error{{it.isTypeScript ? ': Error | undefined' : ''}} , val{{it.isTypeScript ? ': string' : ''}}) => {
+      updateIntroWhisper(val, numClones);
+    },
+  };
+  const updatableLabelInput{{it.isTypeScript ? ': whisper.TextInput' : ''}} = {
+    type: WhisperComponentType.TextInput,
+    label: "Change Whisper Label",
+    onChange: (_error{{it.isTypeScript ? ': Error | undefined' : ''}} , val{{it.isTypeScript ? ': string' : ''}}) => {
+      updateIntroWhisper(newMessage, numClones, val);
+    },
+  };
+  const resetButton{{it.isTypeScript ? ': whisper.Button' : ''}} = {
+    type: WhisperComponentType.Button,
+    label: "Reset Clones",
+    size: ButtonSize.Large,
+    buttonStyle: ButtonStyle.Secondary,
+    onClick: () => {
+      numClones = 1;
+      console.log(`Resetting number of clones: ${numClones}`);
+      updateIntroWhisper(newMessage, numClones);
+    },
+  };
+  const clonedComponents{{it.isTypeScript ? ': ChildComponents[]' : ''}} = [];
+  for (let i = numClones; i > 0; i--) {
+    const clone{{it.isTypeScript ? ': whisper.Button' : ''}} = {
+      type: WhisperComponentType.Button,
+      label: "Clone Me",
+      onClick: () => {
+        numClones++;
+        console.log(`Adding another clone: ${numClones}`);
+        updateIntroWhisper(newMessage, numClones);
+      },
+    };
+    clonedComponents.push(clone);
+  }
+
+  return [
+    introMessage,
+    divider,
+    collapseBox,
+    divider,
+    boxHeader,
+    box,
+    divider,
+    exampleComponentsHeading,
+    textInput,
+    email,
+    password,
+    telephone,
+    button,
+    link,
+    checkbox,
+    pair,
+    numberInput,
+    select,
+    radioBtn,
+    divider,
+    updatableComponentsHeading,
+    updatableMessage,
+    updatableMessageInput,
+    updatableLabelInput,
+    resetButton,
+    ...clonedComponents,
+  ];
+}
+
+async function createIntroWhisper() {
+  WHISPER = await whisper.create({
+    components: createIntroWhisperComponents(),
     label: "Loop Started",
     onClose: () => console.log("{{it.projectName}} intro whisper was closed."),
   });
 }
 
+function updateIntroWhisper(
+  newMessage{{it.isTypeScript ? '?: string' : ''}},
+  numClones{{it.isTypeScript ? ': number' : ''}} = 1,
+  label{{it.isTypeScript ? ': string' : ''}} = "Loop Started"
+) {
+  WHISPER.update(
+    { label, components: createIntroWhisperComponents(newMessage, numClones) },
+    (err{{it.isTypeScript ? ': Error' : ''}}) =>
+      err && console.error("There was an error updating the whisper", err)
+  );
+}
+
 (async function main(){{(it.isTypeScript ? ': Promise<void>' : '') | safe}} {
   console.log("{{it.projectName}} loop started");
 
-  createIntroWhisper();
-
+  await createIntroWhisper();
 {{ @each(it.aptitudes) => aptitude }}
+
 {{ @if (aptitude === 'clipboard') }}
   // Example for clipboard aptitude.
   clipboard.listen(false, (text{{it.isTypeScript ? ': string' : ''}}) => {
@@ -206,7 +302,6 @@ function createIntroWhisper() {
       ],
     });
   });
-
 {{ #elif (aptitude === 'filesystem') }}
   // Example for filesystem aptitude. This uses relative paths and, when you do this, the loop is
   // actually accessing a new "work" directory of its own. This work directory is automatically
@@ -239,7 +334,6 @@ function createIntroWhisper() {
   });
 
   await filesystem.remove(dirPath);
-
 {{ #elif (aptitude === 'keyboard') }}
   // Example for keyboard aptitude.
   keyboard.listenText((text{{it.isTypeScript ? ': string' : ''}}) => {
@@ -253,7 +347,6 @@ function createIntroWhisper() {
       ],
     })
   });
-
 {{ #elif (aptitude === 'network') }}
   // Example for network aptitude.
   const currentDate = new Date();
@@ -306,7 +399,6 @@ function createIntroWhisper() {
     label: "Example for Network Aptitude (FDA Recalls)",
     components: components,
   });
-
 {{ #elif (aptitude === 'ui') }}
   // Example for search aptitudes.
   const callback = (text{{it.isTypeScript ? ': string' : ''}}) => {
@@ -323,7 +415,6 @@ function createIntroWhisper() {
 
   ui.listenSearchbar(callback);
   ui.listenGlobalSearch(callback);
-
 {{ #elif (aptitude === 'window') }}
   // Example for window aptitude.
   window.listenActiveWindow((aw) => {
@@ -347,7 +438,6 @@ function createIntroWhisper() {
       ],
     });
   });
-
 {{ /if }}
 {{/each}}
 })()

--- a/src/templates/src/index.ts.squirrelly
+++ b/src/templates/src/index.ts.squirrelly
@@ -173,44 +173,44 @@ function createIntroWhisperComponents(
 
   // Showing how to use whisper.update
   const updatableComponentsHeading{{it.isTypeScript ? ': whisper.Markdown' : ''}} = {
-    type: WhisperComponentType.Markdown,
+    type: whisper.WhisperComponentType.Markdown,
     body: "# Updatable Whisper Components",
   };
   const updatableMessage{{it.isTypeScript ? ': whisper.Message' : ''}} = {
-    type: WhisperComponentType.Message,
+    type: whisper.WhisperComponentType.Message,
     header: "This is a component hooked up to Updatable Whisper logic",
     body: newMessage || "Type in the field below to update this line of text",
-    style: Urgency.Success,
+    style: whisper.Urgency.Success,
   };
   const updatableMessageInput{{it.isTypeScript ? ': whisper.TextInput' : ''}} = {
-    type: WhisperComponentType.TextInput,
+    type: whisper.WhisperComponentType.TextInput,
     label: "New Text Input",
     onChange: (_error{{it.isTypeScript ? ': Error | undefined' : ''}} , val{{it.isTypeScript ? ': string' : ''}}) => {
       updateIntroWhisper(val, numClones);
     },
   };
   const updatableLabelInput{{it.isTypeScript ? ': whisper.TextInput' : ''}} = {
-    type: WhisperComponentType.TextInput,
+    type: whisper.WhisperComponentType.TextInput,
     label: "Change Whisper Label",
     onChange: (_error{{it.isTypeScript ? ': Error | undefined' : ''}} , val{{it.isTypeScript ? ': string' : ''}}) => {
       updateIntroWhisper(newMessage, numClones, val);
     },
   };
   const resetButton{{it.isTypeScript ? ': whisper.Button' : ''}} = {
-    type: WhisperComponentType.Button,
+    type: whisper.WhisperComponentType.Button,
     label: "Reset Clones",
-    size: ButtonSize.Large,
-    buttonStyle: ButtonStyle.Secondary,
+    size: whisper.ButtonSize.Large,
+    buttonStyle: whisper.ButtonStyle.Secondary,
     onClick: () => {
       numClones = 1;
       console.log(`Resetting number of clones: ${numClones}`);
       updateIntroWhisper(newMessage, numClones);
     },
   };
-  const clonedComponents{{it.isTypeScript ? ': ChildComponents[]' : ''}} = [];
+  const clonedComponents{{it.isTypeScript ? ': whisper.ChildComponents[]' : ''}} = [];
   for (let i = numClones; i > 0; i--) {
     const clone{{it.isTypeScript ? ': whisper.Button' : ''}} = {
-      type: WhisperComponentType.Button,
+      type: whisper.WhisperComponentType.Button,
       label: "Clone Me",
       onClick: () => {
         numClones++;


### PR DESCRIPTION
Adding some components at the bottom of the example whisper that take advantage of the power of updatable whispers. One is a Message component that can have its text updated with a TextField and another is a button that clones itself showing off how new components can be added as needed. 
Logic consists mostly of a global `WHISPER` variable to track current state and having the component building moved to its own function to generate initial and updated components.

Other changes:
1. vscode version was throwing Dependabot errors. Ran `npm audit fix` 
2. Added some template logic on the imports to only import aptitudes that were selected
3. General spacing fixes down at the bottom based on upcoming ESLint/Prettier fixes