### PR TITLE
[HELPS-769] Write functional tests for a Typescript loop

### DIFF
--- a/src/templates/package.json.squirrelly
+++ b/src/templates/package.json.squirrelly
@@ -5,8 +5,8 @@
   "main": "src/index.{{it.isTypeScript ? 'ts' : 'js'}}",
   "scripts": {
     "build": "webpack --entry ./src/index.{{it.isTypeScript ? 'ts' : 'js'}} --config ./node_modules/@oliveai/ldk/dist/webpack/config.js",
-    "test": "jest",
-    "test:coverage": "jest --collect-coverage",
+    "test": "jest --maxWorkers=1",
+    "test:coverage": "npm run test -- --collect-coverage",
     "lint": "eslint ./ --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix"
   },
@@ -59,7 +59,8 @@
           "ignoreCodes": [
             151001
           ]
-        }
+        },
+        "isolatedModules": true
       }
     },
 {{ /if }}

--- a/src/templates/wip/src/aptitudes/clipboard/clipboardListener.test.ts
+++ b/src/templates/wip/src/aptitudes/clipboard/clipboardListener.test.ts
@@ -1,0 +1,33 @@
+import { clipboard } from '@oliveai/ldk';
+import { ClipboardWhisper } from '../../whispers';
+import clipboardListener, { handler } from './clipboardListener';
+
+jest.mock('@oliveai/ldk');
+
+const clipboardShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    ClipboardWhisper: jest.fn().mockImplementation(() => {
+      return { show: clipboardShowSpy };
+    }),
+  };
+});
+
+describe('Clipboard Listener', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start the clipboard listener', () => {
+    clipboardListener.listen();
+
+    expect(clipboard.listen).toBeCalledWith(false, handler);
+  });
+
+  it('should create the whisper when handler is triggered', () => {
+    handler('test');
+
+    expect(ClipboardWhisper).toBeCalledWith('test');
+    expect(clipboardShowSpy).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/clipboard/clipboardListener.ts
+++ b/src/templates/wip/src/aptitudes/clipboard/clipboardListener.ts
@@ -1,0 +1,14 @@
+import { clipboard } from '@oliveai/ldk';
+
+import { ClipboardWhisper } from '../../whispers';
+
+const handler = (text: string) => {
+  const whisper = new ClipboardWhisper(text);
+  whisper.show();
+};
+const listen = () => {
+  clipboard.listen(false, handler);
+};
+
+export { handler };
+export default { listen };

--- a/src/templates/wip/src/aptitudes/filesystem/filesystemExample.test.ts
+++ b/src/templates/wip/src/aptitudes/filesystem/filesystemExample.test.ts
@@ -1,0 +1,61 @@
+import { filesystem, network } from '@oliveai/ldk';
+import { FilesystemWhisper } from '../../whispers';
+import filesystemExample from './filesystemExample';
+
+jest.mock('@oliveai/ldk');
+
+const filesystemShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    FilesystemWhisper: jest.fn().mockImplementation(() => {
+      return { show: filesystemShowSpy };
+    }),
+  };
+});
+
+const TEST_DIR = 'test-dir';
+const TEST_FILENAME = 'test.txt';
+const WRITE_MODE = 0o755;
+
+describe('Filesystem Example', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should write and read a file then display a whisper with the contents', async () => {
+    const fileContentsStub = 'some text';
+    filesystem.join = jest.fn().mockImplementationOnce((segments) => segments.join('/'));
+    network.encode = jest.fn().mockResolvedValueOnce(new Uint8Array());
+    network.decode = jest.fn().mockResolvedValueOnce(fileContentsStub);
+
+    await filesystemExample.run();
+
+    expect(filesystem.writeFile).toBeCalledWith({
+      path: `${TEST_DIR}/${TEST_FILENAME}`,
+      data: expect.any(Uint8Array),
+      writeOperation: filesystem.WriteOperation.overwrite,
+      writeMode: WRITE_MODE,
+    });
+
+    expect(FilesystemWhisper).toBeCalledWith(fileContentsStub);
+    expect(filesystemShowSpy).toBeCalled();
+
+    expect(filesystem.remove).toBeCalledWith(TEST_DIR);
+  });
+
+  it('should create a new work directory if one does not exist', async () => {
+    filesystem.exists = jest.fn().mockResolvedValueOnce(false);
+
+    await filesystemExample.run();
+
+    expect(filesystem.makeDir).toBeCalledWith(TEST_DIR, WRITE_MODE);
+  });
+
+  it('should not create a new work directory if one already exists', async () => {
+    filesystem.exists = jest.fn().mockResolvedValueOnce(true);
+
+    await filesystemExample.run();
+
+    expect(filesystem.makeDir).not.toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/filesystem/filesystemExample.ts
+++ b/src/templates/wip/src/aptitudes/filesystem/filesystemExample.ts
@@ -1,0 +1,30 @@
+import { filesystem, network } from '@oliveai/ldk';
+
+import { FilesystemWhisper } from '../../whispers';
+
+const run = async () => {
+  const writeMode = 0o755;
+  const dirPath = 'test-dir';
+  if (!(await filesystem.exists(dirPath))) {
+    await filesystem.makeDir(dirPath, writeMode);
+  }
+
+  const filePath = await filesystem.join([dirPath, 'test.txt']);
+  const encodedValue = await network.encode('some text');
+  await filesystem.writeFile({
+    path: filePath,
+    data: encodedValue,
+    writeOperation: filesystem.WriteOperation.overwrite,
+    writeMode,
+  });
+
+  const encodedFileContents = await filesystem.readFile(filePath);
+  const fileContents = await network.decode(encodedFileContents);
+
+  const whisper = new FilesystemWhisper(fileContents);
+  whisper.show();
+
+  await filesystem.remove(dirPath);
+};
+
+export default { run };

--- a/src/templates/wip/src/aptitudes/index.ts
+++ b/src/templates/wip/src/aptitudes/index.ts
@@ -1,0 +1,15 @@
+import clipboardListener from './clipboard/clipboardListener';
+import filesystemExample from './filesystem/filesystemExample';
+import keyboardListener from './keyboard/keyboardListener';
+import networkExample from './network/networkExample';
+import searchListener from './ui/searchListener';
+import activeWindowListener from './window/activeWindowListener';
+
+export {
+  clipboardListener,
+  filesystemExample,
+  keyboardListener,
+  networkExample,
+  searchListener,
+  activeWindowListener,
+};

--- a/src/templates/wip/src/aptitudes/keyboard/keyboardListener.test.ts
+++ b/src/templates/wip/src/aptitudes/keyboard/keyboardListener.test.ts
@@ -1,0 +1,33 @@
+import { keyboard } from '@oliveai/ldk';
+import { KeyboardWhisper } from '../../whispers';
+import keyboardListener, { handler } from './keyboardListener';
+
+jest.mock('@oliveai/ldk');
+
+const keyboardShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    KeyboardWhisper: jest.fn().mockImplementation(() => {
+      return { show: keyboardShowSpy };
+    }),
+  };
+});
+
+describe('Keyboard Listener', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start the keyboard listener', () => {
+    keyboardListener.listen();
+
+    expect(keyboard.listenText).toBeCalledWith(handler);
+  });
+
+  it('should create the whisper when handler is triggered', () => {
+    handler('test');
+
+    expect(KeyboardWhisper).toBeCalledWith('test');
+    expect(keyboardShowSpy).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/keyboard/keyboardListener.ts
+++ b/src/templates/wip/src/aptitudes/keyboard/keyboardListener.ts
@@ -1,0 +1,14 @@
+import { keyboard } from '@oliveai/ldk';
+
+import { KeyboardWhisper } from '../../whispers';
+
+const handler = (text: string) => {
+  const whisper = new KeyboardWhisper(text);
+  whisper.show();
+};
+const listen = () => {
+  keyboard.listenText(handler);
+};
+
+export { handler };
+export default { listen };

--- a/src/templates/wip/src/aptitudes/network/networkExample.test.ts
+++ b/src/templates/wip/src/aptitudes/network/networkExample.test.ts
@@ -1,0 +1,55 @@
+import { network } from '@oliveai/ldk';
+import { oneLine } from 'common-tags';
+import { NetworkWhisper } from '../../whispers';
+import networkExample from './networkExample';
+
+jest.mock('@oliveai/ldk');
+
+const networkShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    NetworkWhisper: jest.fn().mockImplementation(() => {
+      return { show: networkShowSpy };
+    }),
+  };
+});
+
+describe('Network Example', () => {
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date(2021, 0));
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should make a network request and display the result with a whisper', async () => {
+    const responseStub: network.HTTPResponse = {
+      statusCode: 200,
+      body: new Uint8Array(),
+      headers: {},
+    };
+    const responseBodyStub = { results: [] };
+    network.httpRequest = jest.fn().mockResolvedValueOnce(responseStub);
+    network.decode = jest.fn().mockResolvedValueOnce(JSON.stringify(responseBodyStub));
+
+    await networkExample.run();
+
+    expect(network.httpRequest).toBeCalledWith({
+      method: 'GET',
+      url: oneLine`
+      https://api.fda.gov/food/enforcement.json?search=report_date:[
+      20201001
+      +TO+
+      20210101
+      ]&limit=10
+      `,
+    });
+    expect(network.decode).toBeCalledWith(responseStub.body);
+    expect(NetworkWhisper).toBeCalledWith(responseBodyStub.results);
+    expect(networkShowSpy).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/network/networkExample.ts
+++ b/src/templates/wip/src/aptitudes/network/networkExample.ts
@@ -1,0 +1,30 @@
+import { network } from '@oliveai/ldk';
+import { oneLine } from 'common-tags';
+import { add, format } from 'date-fns';
+
+import { NetworkWhisper } from '../../whispers';
+
+const run = async () => {
+  const currentDate = new Date();
+  const threeMonthsAgo = add(currentDate, { months: -3 });
+  const request: network.HTTPRequest = {
+    method: 'GET',
+    url: oneLine`
+    https://api.fda.gov/food/enforcement.json?search=report_date:[
+    ${format(threeMonthsAgo, 'yyyyMMdd')}
+    +TO+
+    ${format(currentDate, 'yyyyMMdd')}
+    ]&limit=10
+    `,
+  };
+
+  const response = await network.httpRequest(request);
+  const decodedBody = await network.decode(response.body);
+  const parsedObject = JSON.parse(decodedBody);
+  const recalls = parsedObject.results;
+
+  const whisper = new NetworkWhisper(recalls);
+  whisper.show();
+};
+
+export default { run };

--- a/src/templates/wip/src/aptitudes/ui/searchListener.test.ts
+++ b/src/templates/wip/src/aptitudes/ui/searchListener.test.ts
@@ -1,0 +1,34 @@
+import { ui } from '@oliveai/ldk';
+import { UiWhisper } from '../../whispers';
+import searchListener, { handler } from './searchListener';
+
+jest.mock('@oliveai/ldk');
+
+const uiShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    UiWhisper: jest.fn().mockImplementation(() => {
+      return { show: uiShowSpy };
+    }),
+  };
+});
+
+describe('UI Search Listener', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start the ui listener', () => {
+    searchListener.listen();
+
+    expect(ui.listenGlobalSearch).toBeCalledWith(handler);
+    expect(ui.listenSearchbar).toBeCalledWith(handler);
+  });
+
+  it('should create the whisper when handler is triggered', () => {
+    handler('test');
+
+    expect(UiWhisper).toBeCalledWith('test');
+    expect(uiShowSpy).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/ui/searchListener.ts
+++ b/src/templates/wip/src/aptitudes/ui/searchListener.ts
@@ -1,0 +1,15 @@
+import { ui } from '@oliveai/ldk';
+
+import { UiWhisper } from '../../whispers';
+
+const handler = (text: string) => {
+  const whisper = new UiWhisper(text);
+  whisper.show();
+};
+const listen = () => {
+  ui.listenGlobalSearch(handler);
+  ui.listenSearchbar(handler);
+};
+
+export { handler };
+export default { listen };

--- a/src/templates/wip/src/aptitudes/window/activeWindowListener.test.ts
+++ b/src/templates/wip/src/aptitudes/window/activeWindowListener.test.ts
@@ -1,0 +1,35 @@
+import { window } from '@oliveai/ldk';
+import { WindowWhisper } from '../../whispers';
+import activeWindowListener, { handler } from './activeWindowListener';
+
+jest.mock('@oliveai/ldk');
+
+const windowShowSpy = jest.fn();
+jest.mock('../../whispers', () => {
+  return {
+    WindowWhisper: jest.fn().mockImplementation(() => {
+      return { show: windowShowSpy };
+    }),
+  };
+});
+
+describe('Active Window Listener', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start the active window listener', () => {
+    activeWindowListener.listen();
+
+    expect(window.listenActiveWindow).toBeCalledWith(handler);
+  });
+
+  it('should create the whisper when handler is triggered', () => {
+    const activeWindowStub = {} as window.WindowInfo;
+
+    handler(activeWindowStub);
+
+    expect(WindowWhisper).toBeCalledWith(activeWindowStub);
+    expect(windowShowSpy).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/aptitudes/window/activeWindowListener.ts
+++ b/src/templates/wip/src/aptitudes/window/activeWindowListener.ts
@@ -1,0 +1,14 @@
+import { window } from '@oliveai/ldk';
+
+import { WindowWhisper } from '../../whispers';
+
+const handler = (activeWindow: window.WindowInfo) => {
+  const whisper = new WindowWhisper(activeWindow);
+  whisper.show();
+};
+const listen = () => {
+  window.listenActiveWindow(handler);
+};
+
+export { handler };
+export default { listen };

--- a/src/templates/wip/src/index.test.ts
+++ b/src/templates/wip/src/index.test.ts
@@ -1,0 +1,40 @@
+import {
+  clipboardListener,
+  filesystemExample,
+  keyboardListener,
+  networkExample,
+  searchListener,
+  activeWindowListener,
+} from './aptitudes';
+
+jest.mock('@oliveai/ldk');
+jest.mock('./aptitudes');
+
+const introShowSpy = jest.fn();
+jest.mock('./whispers', () => {
+  return {
+    IntroWhisper: jest.fn().mockImplementation(() => {
+      return { show: introShowSpy };
+    }),
+  };
+});
+
+describe('Project Startup', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start the Intro whisper and all active aptitudes', () => {
+    // eslint-disable-next-line global-require
+    require('.');
+
+    expect(introShowSpy).toBeCalled();
+
+    expect(clipboardListener.listen).toBeCalled();
+    expect(filesystemExample.run).toBeCalled();
+    expect(keyboardListener.listen).toBeCalled();
+    expect(networkExample.run).toBeCalled();
+    expect(searchListener.listen).toBeCalled();
+    expect(activeWindowListener.listen).toBeCalled();
+  });
+});

--- a/src/templates/wip/src/index.ts
+++ b/src/templates/wip/src/index.ts
@@ -1,0 +1,18 @@
+import { IntroWhisper } from './whispers';
+import {
+  clipboardListener,
+  filesystemExample,
+  keyboardListener,
+  networkExample,
+  searchListener,
+  activeWindowListener,
+} from './aptitudes';
+
+new IntroWhisper().show();
+
+clipboardListener.listen();
+filesystemExample.run();
+keyboardListener.listen();
+networkExample.run();
+searchListener.listen();
+activeWindowListener.listen();

--- a/src/templates/wip/src/jestGlobalSetup.js
+++ b/src/templates/wip/src/jestGlobalSetup.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+global.console = {
+  // Override console.log/error in all unit tests
+  log: jest.fn(),
+  error: jest.fn(),
+};

--- a/src/templates/wip/src/whispers/ClipboardWhisper.test.ts
+++ b/src/templates/wip/src/whispers/ClipboardWhisper.test.ts
@@ -1,0 +1,59 @@
+import { whisper } from '@oliveai/ldk';
+import { ClipboardWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = 'test';
+
+describe('Clipboard Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new ClipboardWhisper(TEST_PARAM);
+    const actual = newWhisper.createComponents();
+
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Message,
+        body: TEST_PARAM,
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new ClipboardWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        label: 'Clipboard Aptitude Fired',
+        onClose: ClipboardWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    ClipboardWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Clipboard whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Clipboard whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/ClipboardWhisper.ts
+++ b/src/templates/wip/src/whispers/ClipboardWhisper.ts
@@ -1,0 +1,50 @@
+import { whisper } from '@oliveai/ldk';
+
+interface Props {
+  clipboardText: string;
+}
+export default class ClipboardWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'Clipboard Aptitude Fired';
+
+  props: Props = {
+    clipboardText: '',
+  };
+
+  constructor(clipboardText: string) {
+    this.props.clipboardText = clipboardText;
+  }
+
+  createComponents() {
+    const message: whisper.Message = {
+      type: whisper.WhisperComponentType.Message,
+      body: this.props.clipboardText,
+    };
+
+    return [message];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: ClipboardWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(ClipboardWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Clipboard whisper', err);
+    }
+    console.log('Clipboard whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/FilesystemWhisper.test.ts
+++ b/src/templates/wip/src/whispers/FilesystemWhisper.test.ts
@@ -1,0 +1,59 @@
+import { whisper } from '@oliveai/ldk';
+import { FilesystemWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = 'test';
+
+describe('Filesystem Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new FilesystemWhisper(TEST_PARAM);
+    const actual = newWhisper.createComponents();
+
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Markdown,
+        body: `# Example File Contents\n${TEST_PARAM}`,
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new FilesystemWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        label: 'Example Filesystem Aptitude Whisper',
+        onClose: FilesystemWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    FilesystemWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Filesystem whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Filesystem whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/FilesystemWhisper.ts
+++ b/src/templates/wip/src/whispers/FilesystemWhisper.ts
@@ -1,0 +1,54 @@
+import { whisper } from '@oliveai/ldk';
+import { stripIndent } from 'common-tags';
+
+interface Props {
+  fileContents: string;
+}
+export default class FilesystemWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'Example Filesystem Aptitude Whisper';
+
+  props: Props = {
+    fileContents: '',
+  };
+
+  constructor(fileContents: string) {
+    this.props.fileContents = fileContents;
+  }
+
+  createComponents() {
+    const markdown: whisper.Markdown = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: stripIndent`
+      # Example File Contents
+      ${this.props.fileContents}
+      `,
+    };
+
+    return [markdown];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: FilesystemWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(FilesystemWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Filesystem whisper', err);
+    }
+    console.log('Filesystem whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/IntroWhisper.test.ts
+++ b/src/templates/wip/src/whispers/IntroWhisper.test.ts
@@ -1,0 +1,277 @@
+import { whisper } from '@oliveai/ldk';
+import { IntroWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+const whisperUpdateSpy = jest.fn();
+
+describe('Intro Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest
+      .fn()
+      .mockResolvedValueOnce({ close: whisperCloseSpy, update: whisperUpdateSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new IntroWhisper();
+    const actual = newWhisper.createComponents();
+
+    // Check that we're getting expected component types in the expected order
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Message,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Divider,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.CollapseBox,
+        children: [expect.objectContaining({ type: whisper.WhisperComponentType.Markdown })],
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Divider,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Markdown,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Box,
+        children: [
+          expect.objectContaining({
+            type: whisper.WhisperComponentType.Button,
+          }),
+          expect.objectContaining({
+            type: whisper.WhisperComponentType.Button,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Divider,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Markdown,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.TextInput,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Email,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Password,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Telephone,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Button,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Link,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Checkbox,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.ListPair,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Number,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Select,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.RadioGroup,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Divider,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Markdown,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Message,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.TextInput,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.TextInput,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Button,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Button,
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates components with functional handlers', async () => {
+    const newWhisper = new IntroWhisper();
+    newWhisper.show();
+    await Promise.resolve();
+    const components = newWhisper.createComponents();
+
+    // Check box's first button onClick
+    ((components[5] as whisper.Box).children[0] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Button 1 clicked.');
+
+    // Check box's second button onClick
+    ((components[5] as whisper.Box).children[1] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Button 2 clicked.');
+
+    // Check textInput's onChange
+    (components[8] as whisper.TextInput).onChange(null, 'test', null);
+    expect(console.log).toBeCalledWith('Text changed: ', 'test');
+
+    // Check email's onChange
+    (components[9] as whisper.Email).onChange(null, 'test', null);
+    expect(console.log).toBeCalledWith('Email changed: ', 'test');
+
+    // Check password's onChange
+    (components[10] as whisper.Password).onChange(null, 'test', null);
+    expect(console.log).toBeCalledWith('Password changed: ', 'test');
+
+    // Check telephone's onChange
+    (components[11] as whisper.Telephone).onChange(null, 'test', null);
+    expect(console.log).toBeCalledWith('Telephone number changed: ', 'test');
+
+    // Check button's onClick
+    (components[12] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Button clicked.');
+
+    // Check link's onClick
+    (components[13] as whisper.Link).onClick(null, null);
+    expect(console.log).toBeCalledWith('Link clicked.');
+
+    // Check checkbox's onChange
+    (components[14] as whisper.Checkbox).onChange(null, true, null);
+    expect(console.log).toBeCalledWith('Checkbox clicked: ', true);
+
+    // Check numberInput's onChange
+    (components[16] as whisper.NumberInput).onChange(null, 0, null);
+    expect(console.log).toBeCalledWith('Number changed: ', 0);
+
+    // Check select's onSelect
+    (components[17] as whisper.Select).onSelect(null, 0, null);
+    expect(console.log).toBeCalledWith('Selected: ', 0);
+
+    // Check radioBtn's onSelect
+    (components[18] as whisper.RadioGroup).onSelect(null, 0, null);
+    expect(console.log).toBeCalledWith('Radio button option selected: ', 0);
+
+    // Check updatableMessageInput's onSelect
+    (components[22] as whisper.TextInput).onChange(null, 'test message', null);
+    expect(console.log).toBeCalledWith('Updating message text: ', 'test message');
+    expect(whisperUpdateSpy).toBeCalled();
+    expect(newWhisper.props.newMessage).toEqual('test message');
+
+    // Check updatableLabelInput's onSelect
+    (components[23] as whisper.TextInput).onChange(null, 'test label', null);
+    expect(console.log).toBeCalledWith('Updating whisper label: ', 'test label');
+    expect(whisperUpdateSpy).toBeCalled();
+    expect(newWhisper.props.label).toEqual('test label');
+
+    // Check clicking on a clone button twice
+    (components[25] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Adding another clone: ', 2);
+    expect(whisperUpdateSpy).toBeCalled();
+    expect(newWhisper.props.numClones).toEqual(2);
+    (components[25] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Adding another clone: ', 3);
+    expect(whisperUpdateSpy).toBeCalled();
+    expect(newWhisper.props.numClones).toEqual(3);
+
+    // Check clicking on reset clones button
+    (components[24] as whisper.Button).onClick(null, null);
+    expect(console.log).toBeCalledWith('Resetting number of clones: ', 1);
+    expect(whisperUpdateSpy).toBeCalled();
+    expect(newWhisper.props.numClones).toEqual(1);
+  });
+
+  it('uses default values for updatable components', async () => {
+    const newWhisper = new IntroWhisper();
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.update({});
+
+    expect(whisperUpdateSpy).toBeCalledWith({
+      label: 'jest - Intro Whisper',
+      components: expect.arrayContaining([
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Message,
+          body: 'Type in the field below to update this line of text',
+        }),
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Button,
+          label: 'Clone Me',
+        }),
+      ]),
+    });
+  });
+
+  it('updates as expected for passed in params', async () => {
+    const newWhisper = new IntroWhisper();
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.update({ newMessage: 'test message', numClones: 3, label: 'test label' });
+
+    expect(whisperUpdateSpy).toBeCalledWith({
+      label: 'test label',
+      components: expect.arrayContaining([
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Message,
+          body: 'test message',
+        }),
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Button,
+          label: 'Clone Me',
+        }),
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Button,
+          label: 'Clone Me',
+        }),
+        expect.objectContaining({
+          type: whisper.WhisperComponentType.Button,
+          label: 'Clone Me',
+        }),
+      ]),
+    });
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new IntroWhisper();
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        label: 'jest - Intro Whisper',
+        onClose: IntroWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    IntroWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Intro whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Intro whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/IntroWhisper.ts
+++ b/src/templates/wip/src/whispers/IntroWhisper.ts
@@ -1,0 +1,276 @@
+import { whisper } from '@oliveai/ldk';
+import { stripIndent } from 'common-tags';
+
+interface Props {
+  newMessage: string;
+  numClones: number;
+  label: string;
+}
+export default class IntroWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'jest - Intro Whisper';
+
+  props: Props = {
+    newMessage: '',
+    numClones: 1,
+    label: '',
+  };
+
+  createComponents() {
+    const divider: whisper.Divider = {
+      type: whisper.WhisperComponentType.Divider,
+    };
+
+    // Intro message.
+    const introMessage: whisper.Message = {
+      type: whisper.WhisperComponentType.Message,
+      body: 'These are some components you can use in whispers.',
+      style: whisper.Urgency.Success,
+    };
+
+    // Collapse box.
+    const collapsibleContent: whisper.Markdown = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: stripIndent`
+      # Collapsible Section
+      Content you put here can be expanded/collapsed.
+      `,
+    };
+    const collapseBox: whisper.CollapseBox = {
+      type: whisper.WhisperComponentType.CollapseBox,
+      children: [collapsibleContent],
+      open: true,
+    };
+
+    // Box example.
+    const boxHeader: whisper.Markdown = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: '# Box with Child Components',
+    };
+    const firstButton: whisper.Button = {
+      type: whisper.WhisperComponentType.Button,
+      label: 'Button 1',
+      onClick: () => {
+        console.log('Button 1 clicked.');
+      },
+    };
+    const secondButton: whisper.Button = {
+      type: whisper.WhisperComponentType.Button,
+      label: 'Button 2',
+      onClick: () => {
+        console.log('Button 2 clicked.');
+      },
+    };
+    const box: whisper.Box = {
+      type: whisper.WhisperComponentType.Box,
+      children: [firstButton, secondButton],
+      direction: whisper.Direction.Horizontal,
+      justifyContent: whisper.JustifyContent.SpaceEvenly,
+    };
+
+    // Various example components.
+    const exampleComponentsHeading: whisper.Markdown = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: '# Example Components',
+    };
+    const textInput: whisper.TextInput = {
+      type: whisper.WhisperComponentType.TextInput,
+      label: 'Text Input',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Text changed: ', val);
+      },
+    };
+    const email: whisper.Email = {
+      type: whisper.WhisperComponentType.Email,
+      label: 'Email',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Email changed: ', val);
+      },
+    };
+    const password: whisper.Password = {
+      type: whisper.WhisperComponentType.Password,
+      label: 'Password',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Password changed: ', val);
+      },
+    };
+    const telephone: whisper.Telephone = {
+      type: whisper.WhisperComponentType.Telephone,
+      label: 'Telephone Number',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Telephone number changed: ', val);
+      },
+    };
+    const button: whisper.Button = {
+      type: whisper.WhisperComponentType.Button,
+      label: 'Button',
+      onClick: () => {
+        console.log('Button clicked.');
+      },
+    };
+    const link: whisper.Link = {
+      type: whisper.WhisperComponentType.Link,
+      text: 'Example of a link',
+      onClick: () => {
+        console.log('Link clicked.');
+      },
+    };
+    const checkbox: whisper.Checkbox = {
+      type: whisper.WhisperComponentType.Checkbox,
+      label: 'Checkbox',
+      tooltip: "Here's a tooltip.",
+      value: false,
+      onChange: (_error: Error | undefined, val: boolean) => {
+        console.log('Checkbox clicked: ', val);
+      },
+    };
+    const pair: whisper.ListPair = {
+      type: whisper.WhisperComponentType.ListPair,
+      copyable: true,
+      label: 'List pair example:',
+      value: 'This value is copyable.',
+      style: whisper.Urgency.None,
+    };
+    const numberInput: whisper.NumberInput = {
+      type: whisper.WhisperComponentType.Number,
+      value: 6,
+      max: 10,
+      min: 1,
+      step: 2,
+      tooltip: 'Number Input',
+      label: 'Number Input',
+      onChange: (_error: Error | undefined, val: number) => {
+        console.log('Number changed: ', val);
+      },
+    };
+    const select: whisper.Select = {
+      type: whisper.WhisperComponentType.Select,
+      label: 'Select Box',
+      options: ['One', 'Two', 'Three'],
+      selected: 0,
+      onSelect: (_error: Error | undefined, val: number) => {
+        console.log('Selected: ', val);
+      },
+    };
+    const radioBtn: whisper.RadioGroup = {
+      type: whisper.WhisperComponentType.RadioGroup,
+      options: ['Option 1', 'Option 2', 'Option 3'],
+      onSelect: (_error: Error | undefined, val: number) => {
+        console.log('Radio button option selected: ', val);
+      },
+    };
+
+    // Showing how to use whisper.update
+    const updatableComponentsHeading: whisper.Markdown = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: '# Updatable Whisper Components',
+    };
+    const updatableMessage: whisper.Message = {
+      type: whisper.WhisperComponentType.Message,
+      header: 'This is a component hooked up to Updatable Whisper logic',
+      body: this.props.newMessage || 'Type in the field below to update this line of text',
+      style: whisper.Urgency.Success,
+    };
+    const updatableMessageInput: whisper.TextInput = {
+      type: whisper.WhisperComponentType.TextInput,
+      label: 'New Text Input',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Updating message text: ', val);
+        this.update({ newMessage: val });
+      },
+    };
+    const updatableLabelInput: whisper.TextInput = {
+      type: whisper.WhisperComponentType.TextInput,
+      label: 'Change Whisper Label',
+      onChange: (_error: Error | undefined, val: string) => {
+        console.log('Updating whisper label: ', val);
+        this.update({ label: val });
+      },
+    };
+    const resetButton: whisper.Button = {
+      type: whisper.WhisperComponentType.Button,
+      label: 'Reset Clones',
+      size: whisper.ButtonSize.Large,
+      buttonStyle: whisper.ButtonStyle.Secondary,
+      onClick: () => {
+        const numClones = 1;
+        console.log('Resetting number of clones: ', numClones);
+        this.update({ numClones });
+      },
+    };
+    const clonedComponents: whisper.ChildComponents[] = [];
+    for (let i = this.props.numClones; i > 0; i -= 1) {
+      const clone: whisper.Button = {
+        type: whisper.WhisperComponentType.Button,
+        label: 'Clone Me',
+        onClick: () => {
+          const numClones = this.props.numClones + 1;
+          console.log('Adding another clone: ', numClones);
+          this.update({ numClones });
+        },
+      };
+      clonedComponents.push(clone);
+    }
+
+    return [
+      introMessage,
+      divider,
+      collapseBox,
+      divider,
+      boxHeader,
+      box,
+      divider,
+      exampleComponentsHeading,
+      textInput,
+      email,
+      password,
+      telephone,
+      button,
+      link,
+      checkbox,
+      pair,
+      numberInput,
+      select,
+      radioBtn,
+      divider,
+      updatableComponentsHeading,
+      updatableMessage,
+      updatableMessageInput,
+      updatableLabelInput,
+      resetButton,
+      ...clonedComponents,
+    ];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: IntroWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  update(props: Partial<Props>) {
+    this.props = { ...this.props, ...props };
+    this.whisper.update({
+      label: this.props.label || this.label,
+      components: this.createComponents(),
+    });
+  }
+
+  close() {
+    this.whisper.close(IntroWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Intro whisper', err);
+    }
+    console.log('Intro whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/KeyboardWhisper.test.ts
+++ b/src/templates/wip/src/whispers/KeyboardWhisper.test.ts
@@ -1,0 +1,60 @@
+import { whisper } from '@oliveai/ldk';
+import { KeyboardWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = 'test';
+
+describe('Keyboard Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new KeyboardWhisper(TEST_PARAM);
+    const actual = newWhisper.createComponents();
+
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Message,
+        body: TEST_PARAM,
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new KeyboardWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        components: newWhisper.createComponents(),
+        label: 'Keyboard Aptitude Fired',
+        onClose: KeyboardWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    KeyboardWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Keyboard whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Keyboard whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/KeyboardWhisper.ts
+++ b/src/templates/wip/src/whispers/KeyboardWhisper.ts
@@ -1,0 +1,50 @@
+import { whisper } from '@oliveai/ldk';
+
+interface Props {
+  keyboardText: string;
+}
+export default class KeyboardWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'Keyboard Aptitude Fired';
+
+  props: Props = {
+    keyboardText: '',
+  };
+
+  constructor(keyboardText: string) {
+    this.props.keyboardText = keyboardText;
+  }
+
+  createComponents() {
+    const message: whisper.Message = {
+      type: whisper.WhisperComponentType.Message,
+      body: this.props.keyboardText,
+    };
+
+    return [message];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: KeyboardWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(KeyboardWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Keyboard whisper', err);
+    }
+    console.log('Keyboard whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/NetworkWhisper.test.ts
+++ b/src/templates/wip/src/whispers/NetworkWhisper.test.ts
@@ -1,0 +1,92 @@
+import { whisper } from '@oliveai/ldk';
+import { NetworkWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = [
+  {
+    recalling_firm: 'recalling_firm 1',
+    recall_initiation_date: 'recall_initiation_date 1',
+    recall_number: 'recall_number 1',
+    product_description: 'product_description 1',
+    reason_for_recall: 'reason_for_recall 1',
+  },
+  {
+    recalling_firm: 'recalling_firm 2',
+    recall_initiation_date: 'recall_initiation_date 2',
+    recall_number: 'recall_number 2',
+    product_description: 'product_description 2',
+    reason_for_recall: 'reason_for_recall 2',
+  },
+];
+
+describe('Network Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected with proper onClick logic', () => {
+    const newWhisper = new NetworkWhisper(TEST_PARAM);
+    const actualComponents = newWhisper.createComponents();
+
+    const expectedComponents = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Link,
+        text: 'recalling_firm 1 (recall_initiation_date 1)',
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Link,
+        text: 'recalling_firm 2 (recall_initiation_date 2)',
+      }),
+    ];
+
+    expect(actualComponents).toEqual(expectedComponents);
+
+    actualComponents[0].onClick();
+
+    const expectedSubWhisper = {
+      label: 'Recall for recalling_firm 1',
+      components: [
+        {
+          type: whisper.WhisperComponentType.Markdown,
+          body: '# Recalling Firm\nrecalling_firm 1\n# Recall Number\nrecall_number 1\n# Product Description\nproduct_description 1\n# Reason for Recall\nreason_for_recall 1',
+        },
+      ],
+    };
+
+    expect(whisper.create).toBeCalledWith(expectedSubWhisper);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new NetworkWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        label: 'Example for Network Aptitude (FDA Recalls)',
+        onClose: NetworkWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    NetworkWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Network whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Network whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/NetworkWhisper.ts
+++ b/src/templates/wip/src/whispers/NetworkWhisper.ts
@@ -1,0 +1,79 @@
+import { whisper } from '@oliveai/ldk';
+import { stripIndent } from 'common-tags';
+
+type Recall = {
+  [key: string]: string;
+};
+interface Props {
+  recalls: Recall[];
+}
+export default class NetworkWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'Example for Network Aptitude (FDA Recalls)';
+
+  props: Props = {
+    recalls: [],
+  };
+
+  constructor(recalls: Recall[]) {
+    this.props.recalls = recalls;
+  }
+
+  createComponents() {
+    const components = [];
+    this.props.recalls.forEach((recall) => {
+      components.push({
+        type: whisper.WhisperComponentType.Link,
+        text: `${recall.recalling_firm} (${recall.recall_initiation_date})`,
+        onClick: () => {
+          const markdown = stripIndent`
+          # Recalling Firm
+          ${recall.recalling_firm}
+          # Recall Number
+          ${recall.recall_number}
+          # Product Description
+          ${recall.product_description}
+          # Reason for Recall
+          ${recall.reason_for_recall}
+          `;
+
+          whisper.create({
+            label: `Recall for ${recall.recalling_firm}`,
+            components: [
+              {
+                type: whisper.WhisperComponentType.Markdown,
+                body: markdown,
+              },
+            ],
+          });
+        },
+      });
+    });
+
+    return components;
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: NetworkWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(NetworkWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Network whisper', err);
+    }
+    console.log('Network whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/UiWhisper.test.ts
+++ b/src/templates/wip/src/whispers/UiWhisper.test.ts
@@ -1,0 +1,60 @@
+import { whisper } from '@oliveai/ldk';
+import { UiWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = 'test';
+
+describe('Ui Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new UiWhisper(TEST_PARAM);
+    const actual = newWhisper.createComponents();
+
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.Message,
+        body: TEST_PARAM,
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new UiWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        components: newWhisper.createComponents(),
+        label: 'UI Search Aptitude Fired',
+        onClose: UiWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    UiWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Ui whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Ui whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/UiWhisper.ts
+++ b/src/templates/wip/src/whispers/UiWhisper.ts
@@ -1,0 +1,50 @@
+import { whisper } from '@oliveai/ldk';
+
+interface Props {
+  searchText: string;
+}
+export default class UiWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'UI Search Aptitude Fired';
+
+  props: Props = {
+    searchText: '',
+  };
+
+  constructor(searchText: string) {
+    this.props.searchText = searchText;
+  }
+
+  createComponents() {
+    const message: whisper.Message = {
+      type: whisper.WhisperComponentType.Message,
+      body: this.props.searchText,
+    };
+
+    return [message];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: UiWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(UiWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Ui whisper', err);
+    }
+    console.log('Ui whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/WindowWhisper.test.ts
+++ b/src/templates/wip/src/whispers/WindowWhisper.test.ts
@@ -1,0 +1,66 @@
+import { whisper, window } from '@oliveai/ldk';
+import { WindowWhisper } from '.';
+
+jest.mock('@oliveai/ldk');
+
+const whisperCloseSpy = jest.fn();
+
+const TEST_PARAM = { path: 'test', pid: 0 } as window.WindowInfo;
+
+describe('Window Whisper', () => {
+  beforeEach(() => {
+    whisper.create = jest.fn().mockResolvedValueOnce({ close: whisperCloseSpy });
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates components as expected', () => {
+    const newWhisper = new WindowWhisper(TEST_PARAM);
+    const actual = newWhisper.createComponents();
+
+    const expected = [
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.ListPair,
+        label: 'Window Name',
+        value: TEST_PARAM.path,
+      }),
+      expect.objectContaining({
+        type: whisper.WhisperComponentType.ListPair,
+        label: 'Process Id',
+        value: TEST_PARAM.pid.toString(),
+      }),
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('creates a whisper and closes it gracefully', async () => {
+    const newWhisper = new WindowWhisper(TEST_PARAM);
+    newWhisper.show();
+    await Promise.resolve();
+    newWhisper.close();
+
+    expect(whisper.create).toBeCalledWith(
+      expect.objectContaining({
+        components: newWhisper.createComponents(),
+        label: 'Active Window Changed',
+        onClose: WindowWhisper.onClose,
+      })
+    );
+    expect(whisperCloseSpy).toBeCalled();
+  });
+
+  it.each`
+    scenario              | error
+    ${'without an error'} | ${undefined}
+    ${'with an error'}    | ${new Error('error')}
+  `('should close properly $scenario', ({ error }) => {
+    WindowWhisper.onClose(error);
+
+    if (error) {
+      expect(console.error).toBeCalledWith('There was an error closing Window whisper', error);
+    }
+    expect(console.log).toBeCalledWith('Window whisper closed');
+  });
+});

--- a/src/templates/wip/src/whispers/WindowWhisper.ts
+++ b/src/templates/wip/src/whispers/WindowWhisper.ts
@@ -1,0 +1,59 @@
+import { whisper, window } from '@oliveai/ldk';
+
+interface Props {
+  activeWindow: window.WindowInfo;
+}
+export default class WindowWhisper {
+  whisper: whisper.Whisper;
+
+  label = 'Active Window Changed';
+
+  props: Props = {
+    activeWindow: null,
+  };
+
+  constructor(activeWindow: window.WindowInfo) {
+    this.props.activeWindow = activeWindow;
+  }
+
+  createComponents() {
+    const name: whisper.ListPair = {
+      type: whisper.WhisperComponentType.ListPair,
+      copyable: true,
+      label: 'Window Name',
+      value: this.props.activeWindow.path,
+      style: whisper.Urgency.None,
+    };
+    const pid: whisper.ListPair = {
+      type: whisper.WhisperComponentType.ListPair,
+      copyable: true,
+      label: 'Process Id',
+      value: this.props.activeWindow.pid.toString(),
+      style: whisper.Urgency.None,
+    };
+    return [name, pid];
+  }
+
+  show() {
+    whisper
+      .create({
+        components: this.createComponents(),
+        label: this.label,
+        onClose: WindowWhisper.onClose,
+      })
+      .then((newWhisper) => {
+        this.whisper = newWhisper;
+      });
+  }
+
+  close() {
+    this.whisper.close(WindowWhisper.onClose);
+  }
+
+  static onClose(err?: Error) {
+    if (err) {
+      console.error('There was an error closing Window whisper', err);
+    }
+    console.log('Window whisper closed');
+  }
+}

--- a/src/templates/wip/src/whispers/index.ts
+++ b/src/templates/wip/src/whispers/index.ts
@@ -1,0 +1,17 @@
+import IntroWhisper from './IntroWhisper';
+import ClipboardWhisper from './ClipboardWhisper';
+import FilesystemWhisper from './FilesystemWhisper';
+import KeyboardWhisper from './KeyboardWhisper';
+import NetworkWhisper from './NetworkWhisper';
+import UiWhisper from './UiWhisper';
+import WindowWhisper from './WindowWhisper';
+
+export {
+  IntroWhisper,
+  ClipboardWhisper,
+  FilesystemWhisper,
+  KeyboardWhisper,
+  NetworkWhisper,
+  UiWhisper,
+  WindowWhisper,
+};


### PR DESCRIPTION
Worked in a loop generated by the extension to create a new code structure plus tests with 100% coverage. Putting into a wip directory under templates for now. HELPS-770 will be for updating the tests to be templates then HELPS-771 will be putting it all together

Also small updates in package.json template to optimize jest, reduced run time from >10s to <3s. Something about ts-jest was adding overhead without the extra flags, will need to double check Javascript tests won't be negatively affected

To test locally, copy the wip `src` directory into a new project and run as a normal Typescript loop