### PR TITLE
HELPS-1385: Update loop templates based on recent loop development findings

### DIFF
--- a/loop-templates/package.json
+++ b/loop-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/loop-templates",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Loop templates used by Olive's loop generation tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/loop-templates/package.json
+++ b/loop-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/loop-templates",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Loop templates used by Olive's loop generation tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/loop-templates/templates/package.json.squirrelly
+++ b/loop-templates/templates/package.json.squirrelly
@@ -87,10 +87,7 @@
     "setupFilesAfterEnv": [
       "<rootDir>/src/jestGlobalSetup.js"
     ],
-    "verbose": true,
-    "collectCoverageFrom": [
-      "<rootDir>/src/**/*.{ts,js}"
-    ]
+    "verbose": true
   },
   "ldk": {
     "permissions": {

--- a/loop-templates/templates/src/aptitudes/clipboard/clipboardListener.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/clipboard/clipboardListener.test.ts.squirrelly
@@ -5,11 +5,12 @@ import clipboardListener, { handler } from './clipboardListener';
 jest.mock('@oliveai/ldk');
 
 const mockClipboardShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    ClipboardWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockClipboardShow };
-    }),
+    ClipboardWhisper: {
+      show: jest.fn(() => mockClipboardShow()),
+    },
   };
 });
 
@@ -24,10 +25,10 @@ describe('Clipboard Listener', () => {
     expect(clipboard.listen).toBeCalledWith(false, handler);
   });
 
-  it('should create the whisper when handler is triggered', () => {
-    handler('test');
+  it('should create the whisper when handler is triggered', async () => {
+    await handler('test');
 
-    expect(ClipboardWhisper).toBeCalledWith('test');
+    expect(ClipboardWhisper.show).toBeCalledWith('test');
     expect(mockClipboardShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/clipboard/clipboardListener.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/clipboard/clipboardListener.ts.squirrelly
@@ -2,10 +2,10 @@ import { clipboard } from '@oliveai/ldk';
 
 import { ClipboardWhisper } from '../../whispers';
 
-const handler = (text{{it.isTypeScript ? ': string' : ''}}) => {
-  const whisper = new ClipboardWhisper(text);
-  whisper.show();
+const handler = async (text{{ it.isTypeScript ? ': string' : '' }}) => {
+  await ClipboardWhisper.show(text);
 };
+
 const listen = () => {
   clipboard.listen(false, handler);
 };

--- a/loop-templates/templates/src/aptitudes/filesystem/filesystemExample.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/filesystem/filesystemExample.test.ts.squirrelly
@@ -5,11 +5,12 @@ import filesystemExample from './filesystemExample';
 jest.mock('@oliveai/ldk');
 
 const mockFilesystemShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    FilesystemWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockFilesystemShow };
-    }),
+    FilesystemWhisper: {
+      show: jest.fn(() => mockFilesystemShow()),
+    },
   };
 });
 
@@ -37,7 +38,7 @@ describe('Filesystem Example', () => {
       writeMode: WRITE_MODE,
     });
 
-    expect(FilesystemWhisper).toBeCalledWith(fileContentsStub);
+    expect(FilesystemWhisper.show).toBeCalledWith(fileContentsStub);
     expect(mockFilesystemShow).toBeCalled();
 
     expect(filesystem.remove).toBeCalledWith(TEST_DIR);

--- a/loop-templates/templates/src/aptitudes/filesystem/filesystemExample.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/filesystem/filesystemExample.ts.squirrelly
@@ -21,8 +21,7 @@ const run = async () => {
   const encodedFileContents = await filesystem.readFile(filePath);
   const fileContents = await network.decode(encodedFileContents);
 
-  const whisper = new FilesystemWhisper(fileContents);
-  whisper.show();
+  await FilesystemWhisper.show(fileContents);
 
   await filesystem.remove(dirPath);
 };

--- a/loop-templates/templates/src/aptitudes/index.ts
+++ b/loop-templates/templates/src/aptitudes/index.ts
@@ -12,7 +12,7 @@ const fileMap: FileMap = {
   filesystem: { fileName: 'filesystem', aptitude: 'filesystem' },
   keyboard: { fileName: 'keyboard', aptitude: 'keyboard' },
   network: { fileName: 'network', aptitude: 'network' },
-  ui: { fileName: 'ui', aptitude: 'nonzero' },
+  ui: { fileName: 'ui', aptitude: 'any' },
   window: { fileName: 'window', aptitude: 'window' },
   index: { fileName: 'index.ts', aptitude: 'any' }
 };

--- a/loop-templates/templates/src/aptitudes/keyboard/keyboardListener.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/keyboard/keyboardListener.test.ts.squirrelly
@@ -5,11 +5,12 @@ import keyboardListener, { handler } from './keyboardListener';
 jest.mock('@oliveai/ldk');
 
 const mockKeyboardShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    KeyboardWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockKeyboardShow };
-    }),
+    KeyboardWhisper: {
+      show: jest.fn(() => mockKeyboardShow()),
+    },
   };
 });
 
@@ -24,10 +25,10 @@ describe('Keyboard Listener', () => {
     expect(keyboard.listenText).toBeCalledWith(handler);
   });
 
-  it('should create the whisper when handler is triggered', () => {
-    handler('test');
+  it('should create the whisper when handler is triggered', async () => {
+    await handler('test');
 
-    expect(KeyboardWhisper).toBeCalledWith('test');
+    expect(KeyboardWhisper.show).toBeCalledWith('test');
     expect(mockKeyboardShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/keyboard/keyboardListener.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/keyboard/keyboardListener.ts.squirrelly
@@ -2,9 +2,8 @@ import { keyboard } from '@oliveai/ldk';
 
 import { KeyboardWhisper } from '../../whispers';
 
-const handler = (text{{it.isTypeScript ? ': string' : ''}}) => {
-  const whisper = new KeyboardWhisper(text);
-  whisper.show();
+const handler = async (text{{ it.isTypeScript ? ': string' : '' }}) => {
+  await KeyboardWhisper.show(text);
 };
 const listen = () => {
   keyboard.listenText(handler);

--- a/loop-templates/templates/src/aptitudes/network/networkExample.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/network/networkExample.test.ts.squirrelly
@@ -6,11 +6,12 @@ import networkExample from './networkExample';
 jest.mock('@oliveai/ldk');
 
 const mockNetworkShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    NetworkWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockNetworkShow };
-    }),
+    NetworkWhisper: {
+      show: jest.fn(() => mockNetworkShow()),
+    },
   };
 });
 
@@ -27,7 +28,7 @@ describe('Network Example', () => {
   });
 
   it('should make a network request and display the result with a whisper', async () => {
-    const responseStub{{it.isTypeScript ? ': network.HTTPResponse' : ''}} = {
+    const responseStub{{ it.isTypeScript ? ': network.HTTPResponse' : '' }} = {
       statusCode: 200,
       body: new Uint8Array(),
       headers: {},
@@ -49,7 +50,7 @@ describe('Network Example', () => {
       `,
     });
     expect(network.decode).toBeCalledWith(responseStub.body);
-    expect(NetworkWhisper).toBeCalledWith(responseBodyStub.results);
+    expect(NetworkWhisper.show).toBeCalledWith(responseBodyStub.results);
     expect(mockNetworkShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/network/networkExample.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/network/networkExample.ts.squirrelly
@@ -7,7 +7,7 @@ import { NetworkWhisper } from '../../whispers';
 const run = async () => {
   const currentDate = new Date();
   const threeMonthsAgo = add(currentDate, { months: -3 });
-  const request{{it.isTypeScript ? ': network.HTTPRequest' : ''}} = {
+  const request{{ it.isTypeScript ? ': network.HTTPRequest' : '' }} = {
     method: 'GET',
     url: oneLine`
     https://api.fda.gov/food/enforcement.json?search=report_date:[
@@ -23,8 +23,7 @@ const run = async () => {
   const parsedObject = JSON.parse(decodedBody);
   const recalls = parsedObject.results;
 
-  const whisper = new NetworkWhisper(recalls);
-  whisper.show();
+  await NetworkWhisper.show(recalls);
 };
 
 export default { run };

--- a/loop-templates/templates/src/aptitudes/ui/index.ts
+++ b/loop-templates/templates/src/aptitudes/ui/index.ts
@@ -5,8 +5,8 @@ import searchListener from './searchListener.ts.squirrelly';
 import { FileMap } from '@/types';
 
 const fileMap: FileMap = {
-  openHandlerTest: { fileName: 'openHandler.test.ts', aptitude: 'nonzero' },
-  openHandler: { fileName: 'openHandler.ts', aptitude: 'nonzero' },
+  openHandlerTest: { fileName: 'openHandler.test.ts', aptitude: 'any' },
+  openHandler: { fileName: 'openHandler.ts', aptitude: 'any' },
   searchListenerTest: { fileName: 'searchListener.test.ts', aptitude: 'ui' },
   searchListener: { fileName: 'searchListener.ts', aptitude: 'ui' }
 };

--- a/loop-templates/templates/src/aptitudes/ui/openHandler.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/ui/openHandler.test.ts.squirrelly
@@ -5,10 +5,15 @@ import { handler } from './openHandler';
 jest.mock('@oliveai/ldk');
 
 const mockIntroWhisperShow = jest.fn();
+const mockIntroWhisperSimpleShow = jest.fn();
+
 jest.mock('../../whispers', () => ({
   IntroWhisper: jest.fn(() => ({
     show: mockIntroWhisperShow,
   })),
+  IntroWhisperSimple: {
+    show: jest.fn(() => mockIntroWhisperSimpleShow()),
+  }
 }));
 
 describe('Open Handler', () => {
@@ -20,5 +25,6 @@ describe('Open Handler', () => {
     await handler();
 
     expect(mockIntroWhisperShow).toBeCalled();
+    expect(mockIntroWhisperSimpleShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/ui/openHandler.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/ui/openHandler.ts.squirrelly
@@ -1,9 +1,10 @@
 import { ui } from '@oliveai/ldk';
 
-import { IntroWhisper } from '../../whispers';
+import { IntroWhisper, IntroWhisperSimple } from '../../whispers';
 
 export const handler = async () => {
   new IntroWhisper().show();
+  await IntroWhisperSimple.show();
 };
 
 export default {

--- a/loop-templates/templates/src/aptitudes/ui/searchListener.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/ui/searchListener.test.ts.squirrelly
@@ -5,11 +5,12 @@ import searchListener, { handler } from './searchListener';
 jest.mock('@oliveai/ldk');
 
 const mockUiShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    UiWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockUiShow };
-    }),
+    UiWhisper: {
+      show: jest.fn(() => mockUiShow()),
+    },
   };
 });
 
@@ -28,7 +29,7 @@ describe('UI Search Listener', () => {
   it('should create the whisper when handler is triggered', () => {
     handler('test');
 
-    expect(UiWhisper).toBeCalledWith('test');
+    expect(UiWhisper.show).toBeCalledWith('test');
     expect(mockUiShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/ui/searchListener.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/ui/searchListener.ts.squirrelly
@@ -2,10 +2,10 @@ import { ui } from '@oliveai/ldk';
 
 import { UiWhisper } from '../../whispers';
 
-const handler = (text{{it.isTypeScript ? ': string' : ''}}) => {
-  const whisper = new UiWhisper(text);
-  whisper.show();
+const handler = async (text{{ it.isTypeScript ? ': string' : '' }}) => {
+  await UiWhisper.show(text);
 };
+
 const listen = () => {
   ui.listenGlobalSearch(handler);
   ui.listenSearchbar(handler);

--- a/loop-templates/templates/src/aptitudes/window/activeWindowListener.test.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/window/activeWindowListener.test.ts.squirrelly
@@ -5,11 +5,12 @@ import activeWindowListener, { handler } from './activeWindowListener';
 jest.mock('@oliveai/ldk');
 
 const mockWindowShow = jest.fn();
+
 jest.mock('../../whispers', () => {
   return {
-    WindowWhisper: jest.fn().mockImplementation(() => {
-      return { show: mockWindowShow };
-    }),
+    WindowWhisper: {
+      show: jest.fn(() => mockWindowShow()),
+    },
   };
 });
 
@@ -25,11 +26,11 @@ describe('Active Window Listener', () => {
   });
 
   it('should create the whisper when handler is triggered', () => {
-    const activeWindowStub = {}{{it.isTypeScript ? ' as window.WindowInfo' : ''}};
+    const activeWindowStub = {}{{ it.isTypeScript ? ' as window.WindowInfo' : ''}};
 
     handler(activeWindowStub);
 
-    expect(WindowWhisper).toBeCalledWith(activeWindowStub);
+    expect(WindowWhisper.show).toBeCalledWith(activeWindowStub);
     expect(mockWindowShow).toBeCalled();
   });
 });

--- a/loop-templates/templates/src/aptitudes/window/activeWindowListener.ts.squirrelly
+++ b/loop-templates/templates/src/aptitudes/window/activeWindowListener.ts.squirrelly
@@ -2,10 +2,10 @@ import { window } from '@oliveai/ldk';
 
 import { WindowWhisper } from '../../whispers';
 
-const handler = (activeWindow{{it.isTypeScript ? ': window.WindowInfo' : ''}}) => {
-  const whisper = new WindowWhisper(activeWindow);
-  whisper.show();
+const handler = async (activeWindow{{ it.isTypeScript ? ': window.WindowInfo' : '' }}) => {
+  await WindowWhisper.show(activeWindow);
 };
+
 const listen = () => {
   window.listenActiveWindow(handler);
 };

--- a/loop-templates/templates/src/index.test.ts.squirrelly
+++ b/loop-templates/templates/src/index.test.ts.squirrelly
@@ -18,20 +18,12 @@ import {
 {{ @if (it.aptitudes.includes('window')) }}
   activeWindowListener,
 {{ /if }}
-openHandler,
+  openHandler,
 } from './aptitudes';
 {{ #else }}
 import { openHandler } from './aptitudes';
 {{ /if }}
 jest.mock('./aptitudes');
-
-const mockIntroWhisperShow = jest.fn();
-
-jest.mock('./whispers', () => ({
-  IntroWhisper: jest.fn(() => ({
-    show: mockIntroWhisperShow,
-  })),
-}));
 
 describe('Project Startup', () => {
   afterEach(() => {
@@ -43,7 +35,6 @@ describe('Project Startup', () => {
     await require('.');
     expect(console.log).toBeCalledWith('Example Loop Started');
     expect(openHandler.start).toBeCalled();
-    expect(mockIntroWhisperShow).toBeCalled();
 {{ @if (it.aptitudes.length > 0) }}
 {{ @if (it.aptitudes.includes('clipboard')) }}
     expect(clipboardListener.listen).toBeCalled();

--- a/loop-templates/templates/src/index.ts.squirrelly
+++ b/loop-templates/templates/src/index.ts.squirrelly
@@ -1,5 +1,3 @@
-import { IntroWhisper } from './whispers';
-{{ @if (it.aptitudes.length > 0) }}
 import {
 {{ @if (it.aptitudes.includes('clipboard')) }}
   clipboardListener,
@@ -43,15 +41,4 @@ import {
   activeWindowListener.listen();
 {{ /if }}
   openHandler.start();
-  new IntroWhisper().show();
 })();
-{{ #else }}
-import { openHandler } from './aptitudes';
-
-(async function main(){{ @if (it.isTypeScript) }}{{it.promiseVoid | safe}}{{ /if }} {
-  console.log('Example Loop Started');
-  openHandler.start();
-  new IntroWhisper().show();
-})();
-
-{{ /if }}

--- a/loop-templates/templates/src/whispers/ClipboardWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/ClipboardWhisper.test.ts.squirrelly
@@ -1,5 +1,5 @@
 import { whisper } from '@oliveai/ldk';
-import { ClipboardWhisper } from '.';
+import ClipboardWhisper, { onClose } from './ClipboardWhisper';
 
 jest.mock('@oliveai/ldk');
 
@@ -15,30 +15,20 @@ describe('Clipboard Whisper', () => {
     jest.resetAllMocks();
   });
 
-  it('creates components as expected', () => {
-    const newWhisper = new ClipboardWhisper(TEST_PARAM);
-    const actual = newWhisper.createComponents();
-
-    const expected = [
-      expect.objectContaining({
-        type: whisper.WhisperComponentType.Message,
-        body: TEST_PARAM,
-      }),
-    ];
-
-    expect(actual).toEqual(expected);
-  });
-
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = new ClipboardWhisper(TEST_PARAM);
-    newWhisper.show();
-    await Promise.resolve();
-    newWhisper.close();
+    const newWhisper = await ClipboardWhisper.show(TEST_PARAM);
+    newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
+        components: [
+          {
+            type: whisper.WhisperComponentType.Message,
+            body: TEST_PARAM,
+          },
+        ],
         label: 'Clipboard Aptitude Fired',
-        onClose: ClipboardWhisper.onClose,
+        onClose,
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -49,7 +39,7 @@ describe('Clipboard Whisper', () => {
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
   `('should close properly $scenario', ({ error }) => {
-    ClipboardWhisper.onClose(error);
+    onClose(error);
 
     if (error) {
       expect(console.error).toBeCalledWith('There was an error closing Clipboard whisper', error);

--- a/loop-templates/templates/src/whispers/ClipboardWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/ClipboardWhisper.ts.squirrelly
@@ -1,56 +1,23 @@
 import { whisper } from '@oliveai/ldk';
 
-{{ @if (it.isTypeScript) }}
-interface Props {
-  clipboardText: string;
-}
-{{ /if }}
-export default class ClipboardWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
-
-{{ /if }}
-  constructor(clipboardText{{it.isTypeScript ? ': string' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'Clipboard Aptitude Fired';
-    this.props = {
-      clipboardText,
-    };
+export const onClose = (err{{it.isTypeScript ? '?: Error' : ''}}) => {
+  if (err) {
+    console.error('There was an error closing Clipboard whisper', err);
   }
+  console.log('Clipboard whisper closed');
+};
 
-  createComponents() {
+export default {
+  show: async (clipboardText{{it.isTypeScript ? ': string' : ''}}) => {
     const message{{it.isTypeScript ? ': whisper.Message' : ''}} = {
       type: whisper.WhisperComponentType.Message,
-      body: this.props.clipboardText,
+      body: clipboardText,
     };
 
-    return [message];
-  }
-
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: ClipboardWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
-
-  close() {
-    this.whisper.close(ClipboardWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Clipboard whisper', err);
-    }
-    console.log('Clipboard whisper closed');
-  }
-}
+    return whisper.create({
+      components: [message],
+      label: 'Clipboard Aptitude Fired',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/FilesystemWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/FilesystemWhisper.test.ts.squirrelly
@@ -1,5 +1,5 @@
 import { whisper } from '@oliveai/ldk';
-import { FilesystemWhisper } from '.';
+import FilesystemWhisper, { onClose } from './FilesystemWhisper';
 
 jest.mock('@oliveai/ldk');
 
@@ -15,30 +15,20 @@ describe('Filesystem Whisper', () => {
     jest.resetAllMocks();
   });
 
-  it('creates components as expected', () => {
-    const newWhisper = new FilesystemWhisper(TEST_PARAM);
-    const actual = newWhisper.createComponents();
-
-    const expected = [
-      expect.objectContaining({
-        type: whisper.WhisperComponentType.Markdown,
-        body: `# Example File Contents\n${TEST_PARAM}`,
-      }),
-    ];
-
-    expect(actual).toEqual(expected);
-  });
-
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = new FilesystemWhisper(TEST_PARAM);
-    newWhisper.show();
-    await Promise.resolve();
-    newWhisper.close();
+    const newWhisper = await FilesystemWhisper.show(TEST_PARAM);
+    newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
+        components: [
+          {
+            type: whisper.WhisperComponentType.Markdown,
+            body: expect.stringContaining(TEST_PARAM),
+          },
+        ],
         label: 'Example Filesystem Aptitude Whisper',
-        onClose: FilesystemWhisper.onClose,
+        onClose,
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -49,7 +39,7 @@ describe('Filesystem Whisper', () => {
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
   `('should close properly $scenario', ({ error }) => {
-    FilesystemWhisper.onClose(error);
+    onClose(error);
 
     if (error) {
       expect(console.error).toBeCalledWith('There was an error closing Filesystem whisper', error);

--- a/loop-templates/templates/src/whispers/FilesystemWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/FilesystemWhisper.ts.squirrelly
@@ -1,60 +1,27 @@
 import { whisper } from '@oliveai/ldk';
 import { stripIndent } from 'common-tags';
 
-{{ @if (it.isTypeScript) }}
-interface Props {
-  fileContents: string;
-}
-{{ /if }}
-export default class FilesystemWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
-
-{{ /if }}
-  constructor(fileContents{{it.isTypeScript ? ': string' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'Example Filesystem Aptitude Whisper';
-    this.props = {
-      fileContents,
-    };
+export const onClose = (err{{it.isTypeScript ? '?: Error' : ''}}) => {
+  if (err) {
+    console.error('There was an error closing Filesystem whisper', err);
   }
+  console.log('Filesystem whisper closed');
+};
 
-  createComponents() {
+export default {
+  show: async (fileContents{{it.isTypeScript ? ': string' : ''}}) => {
     const markdown{{it.isTypeScript ? ': whisper.Markdown' : ''}} = {
       type: whisper.WhisperComponentType.Markdown,
       body: stripIndent`
       # Example File Contents
-      ${this.props.fileContents}
+      ${fileContents}
       `,
     };
 
-    return [markdown];
-  }
-
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: FilesystemWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
-
-  close() {
-    this.whisper.close(FilesystemWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Filesystem whisper', err);
-    }
-    console.log('Filesystem whisper closed');
-  }
-}
+    return whisper.create({
+      components: [markdown],
+      label: 'Example Filesystem Aptitude Whisper',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/IntroWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/IntroWhisper.test.ts.squirrelly
@@ -124,89 +124,89 @@ describe('Intro Whisper', () => {
     const box = components[5]{{it.isTypeScript ? ' as whisper.Box' : ''}};
     const boxFirstButton = box.children[0]{{it.isTypeScript ? ' as whisper.Button' : ''}};
     const boxSecondButton = box.children[1]{{it.isTypeScript ? ' as whisper.Button' : ''}};
-    boxFirstButton.onClick(null, null);
+    boxFirstButton.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Button 1 clicked.');
-    boxSecondButton.onClick(null, null);
+    boxSecondButton.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Button 2 clicked.');
 
     // Check textInput's onChange
     const textInput = components[8]{{it.isTypeScript ? ' as whisper.TextInput' : ''}};
-    textInput.onChange(null, 'test', null);
+    textInput.onChange(undefined, 'test', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Text changed: ', 'test');
 
     // Check email's onChange
     const email = components[9]{{it.isTypeScript ? ' as whisper.Email' : ''}};
-    email.onChange(null, 'test', null);
+    email.onChange(undefined, 'test', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Email changed: ', 'test');
 
     // Check password's onChange
     const password = components[10]{{it.isTypeScript ? ' as whisper.Password' : ''}};
-    password.onChange(null, 'test', null);
+    password.onChange(undefined, 'test', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Password changed: ', 'test');
 
     // Check telephone's onChange
     const telephone = components[11]{{it.isTypeScript ? ' as whisper.Telephone' : ''}};
-    telephone.onChange(null, 'test', null);
+    telephone.onChange(undefined, 'test', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Telephone number changed: ', 'test');
 
     // Check button's onClick
     const button = components[12]{{it.isTypeScript ? ' as whisper.Button' : ''}};
-    button.onClick(null, null);
+    button.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Button clicked.');
 
     // Check link's onClick
     const link = components[13]{{it.isTypeScript ? ' as whisper.Link' : ''}};
-    link.onClick(null, null);
+    link.onClick?.(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Link clicked.');
 
     // Check checkbox's onChange
     const checkbox = components[14]{{it.isTypeScript ? ' as whisper.Checkbox' : ''}};
-    checkbox.onChange(null, true, null);
+    checkbox.onChange(undefined, true, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Checkbox clicked: ', true);
 
     // Check numberInput's onChange
     const numberInput = components[16]{{it.isTypeScript ? ' as whisper.NumberInput' : ''}};
-    numberInput.onChange(null, 0, null);
+    numberInput.onChange(undefined, 0, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Number changed: ', 0);
 
     // Check select's onSelect
     const select = components[17]{{it.isTypeScript ? ' as whisper.Select' : ''}};
-    select.onSelect(null, 0, null);
+    select.onSelect(undefined, 0, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Selected: ', 0);
 
     // Check radioBtn's onSelect
     const radioBtn = components[18]{{it.isTypeScript ? ' as whisper.RadioGroup' : ''}};
-    radioBtn.onSelect(null, 0, null);
+    radioBtn.onSelect(undefined, 0, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Radio button option selected: ', 0);
 
     // Check updatableMessageInput's onSelect
     const updatableMessageInput = components[22]{{it.isTypeScript ? ' as whisper.TextInput' : ''}};
-    updatableMessageInput.onChange(null, 'test message', null);
+    updatableMessageInput.onChange(undefined, 'test message', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Updating message text: ', 'test message');
     expect(mockWhisperUpdate).toBeCalled();
     expect(newWhisper.props.newMessage).toEqual('test message');
 
     // Check updatableLabelInput's onSelect
     const updatableLabelInput = components[23]{{it.isTypeScript ? ' as whisper.TextInput' : ''}};
-    updatableLabelInput.onChange(null, 'test label', null);
+    updatableLabelInput.onChange(undefined, 'test label', newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
     expect(console.log).toBeCalledWith('Updating whisper label: ', 'test label');
     expect(mockWhisperUpdate).toBeCalled();
     expect(newWhisper.props.label).toEqual('test label');
 
     // Check clicking on a clone button twice
     const cloneButton = components[25]{{it.isTypeScript ? ' as whisper.Button' : ''}};
-    cloneButton.onClick(null, null);
+    cloneButton.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Adding another clone: ', 2);
     expect(mockWhisperUpdate).toBeCalled();
     expect(newWhisper.props.numClones).toEqual(2);
-    cloneButton.onClick(null, null);
+    cloneButton.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Adding another clone: ', 3);
     expect(mockWhisperUpdate).toBeCalled();
     expect(newWhisper.props.numClones).toEqual(3);
 
     // Check clicking on reset clones button
     const resetClonesButton = components[24]{{it.isTypeScript ? ' as whisper.Button' : ''}};
-    resetClonesButton.onClick(null, null);
+    resetClonesButton.onClick(undefined, newWhisper.whisper{{ it.isTypeScript ? ' as whisper.Whisper' : ''}});
     expect(console.log).toBeCalledWith('Resetting number of clones: ', 1);
     expect(mockWhisperUpdate).toBeCalled();
     expect(newWhisper.props.numClones).toEqual(1);

--- a/loop-templates/templates/src/whispers/IntroWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/IntroWhisper.ts.squirrelly
@@ -8,9 +8,18 @@ interface Props {
   label: string;
 }
 {{ /if }}
+/**
+ * Preferred method for updateable whispers
+ * + Class instances allow more control over updateable props
+ * + Updating whispers requires storing the created whisper object
+ * + Separation of concern for different methods
+ * + Testing makes more sense without explicit exports solely for testing
+ * - Considered overkill for any whispers that don't need updating
+ * @see IntroWhisperSimple for simple whispers
+ */
 export default class IntroWhisper {
 {{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
+  whisper: whisper.Whisper | undefined;
 
   label: string;
 
@@ -267,14 +276,14 @@ export default class IntroWhisper {
 
   update(props{{it.isTypeScript ? ': Partial<Props>' : '' | safe}}) {
     this.props = { ...this.props, ...props };
-    this.whisper.update({
+    this.whisper?.update({
       label: this.props.label || this.label,
       components: this.createComponents(),
     });
   }
 
   close() {
-    this.whisper.close(IntroWhisper.onClose);
+    this.whisper?.close(IntroWhisper.onClose);
   }
 
   static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {

--- a/loop-templates/templates/src/whispers/IntroWhisperSimple.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/IntroWhisperSimple.test.ts.squirrelly
@@ -1,13 +1,11 @@
 import { whisper } from '@oliveai/ldk';
-import UiWhisper, { onClose } from './UiWhisper';
+import IntroWhisperSimple, { onClose } from './IntroWhisperSimple';
 
 jest.mock('@oliveai/ldk');
 
 const mockWhisperClose = jest.fn();
 
-const TEST_PARAM = 'test';
-
-describe('UI Search Whisper', () => {
+describe('Export Default Whisper', () => {
   beforeEach(() => {
     whisper.create = jest.fn().mockResolvedValueOnce({ close: mockWhisperClose });
   });
@@ -16,19 +14,14 @@ describe('UI Search Whisper', () => {
   });
 
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = await UiWhisper.show(TEST_PARAM);
+    const newWhisper = await IntroWhisperSimple.show();
     newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
-        components: [
-          {
-            type: whisper.WhisperComponentType.Message,
-            body: TEST_PARAM,
-          },
-        ],
-        label: 'UI Aptitude Fired',
-        onClose,
+        label: 'Export Default Whisper',
+        components: [expect.objectContaining({ type: whisper.WhisperComponentType.Markdown })],
+        onClose: expect.any(Function),
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -38,12 +31,15 @@ describe('UI Search Whisper', () => {
     scenario              | error
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
-  `('should close properly $scenario', ({ error }) => {
+  `('should close properly $scenario', async ({ error }) => {
     onClose(error);
 
     if (error) {
-      expect(console.error).toBeCalledWith('There was an error closing UI Search whisper', error);
+      expect(console.error).toBeCalledWith(
+        'There was an error closing Export Default whisper',
+        error
+      );
     }
-    expect(console.log).toBeCalledWith('UI Search whisper closed');
+    expect(console.log).toBeCalledWith('Export Default whisper closed');
   });
 });

--- a/loop-templates/templates/src/whispers/IntroWhisperSimple.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/IntroWhisperSimple.ts.squirrelly
@@ -1,0 +1,34 @@
+import { whisper } from '@oliveai/ldk';
+import { stripIndent } from 'common-tags';
+
+export const onClose = (err{{it.isTypeScript ? '?: Error' : ''}}) => {
+  if (err) {
+    console.error('There was an error closing Export Default whisper', err);
+  }
+  console.log('Export Default whisper closed');
+};
+
+/**
+ * Preferred method for simple whispers
+ * + More desired TypeScript style
+ * + Allows for a consistent WhisperName.show() format
+ * + Default export can be named however the developer wants
+ * + Default export does not include test-only exports which can be explicitly imported separately
+ * - Does not support updateable in a clean and easy-to-test way
+ * @see IntroWhisper for updateable whispers
+ */
+export default {
+  show: async () => {
+    const markdown{{it.isTypeScript ? ': whisper.Markdown' : ''}} = {
+      type: whisper.WhisperComponentType.Markdown,
+      body: stripIndent`
+        This is a simple whisper
+      `,
+    };
+    return whisper.create({
+      components: [markdown],
+      label: 'Export Default Whisper',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/KeyboardWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/KeyboardWhisper.test.ts.squirrelly
@@ -1,5 +1,5 @@
 import { whisper } from '@oliveai/ldk';
-import { KeyboardWhisper } from '.';
+import KeyboardWhisper, { onClose } from './KeyboardWhisper';
 
 jest.mock('@oliveai/ldk');
 
@@ -15,31 +15,20 @@ describe('Keyboard Whisper', () => {
     jest.resetAllMocks();
   });
 
-  it('creates components as expected', () => {
-    const newWhisper = new KeyboardWhisper(TEST_PARAM);
-    const actual = newWhisper.createComponents();
-
-    const expected = [
-      expect.objectContaining({
-        type: whisper.WhisperComponentType.Message,
-        body: TEST_PARAM,
-      }),
-    ];
-
-    expect(actual).toEqual(expected);
-  });
-
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = new KeyboardWhisper(TEST_PARAM);
-    newWhisper.show();
-    await Promise.resolve();
-    newWhisper.close();
+    const newWhisper = await KeyboardWhisper.show(TEST_PARAM);
+    newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
-        components: newWhisper.createComponents(),
+        components: [
+          {
+            type: whisper.WhisperComponentType.Message,
+            body: TEST_PARAM,
+          },
+        ],
         label: 'Keyboard Aptitude Fired',
-        onClose: KeyboardWhisper.onClose,
+        onClose,
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -50,7 +39,7 @@ describe('Keyboard Whisper', () => {
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
   `('should close properly $scenario', ({ error }) => {
-    KeyboardWhisper.onClose(error);
+    onClose(error);
 
     if (error) {
       expect(console.error).toBeCalledWith('There was an error closing Keyboard whisper', error);

--- a/loop-templates/templates/src/whispers/KeyboardWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/KeyboardWhisper.ts.squirrelly
@@ -1,56 +1,23 @@
 import { whisper } from '@oliveai/ldk';
 
-{{ @if (it.isTypeScript) }}
-interface Props {
-  keyboardText: string;
-}
-{{ /if }}
-export default class KeyboardWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
-
-{{ /if }}
-  constructor(keyboardText{{it.isTypeScript ? ': string' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'Keyboard Aptitude Fired';
-    this.props = {
-      keyboardText,
-    };
+export const onClose = (err{{it.isTypeScript ? '?: Error' : ''}}) => {
+  if (err) {
+    console.error('There was an error closing Keyboard whisper', err);
   }
+  console.log('Keyboard whisper closed');
+};
 
-  createComponents() {
+export default {
+  show: async (keyboardText{{it.isTypeScript ? ': string' : ''}}) => {
     const message{{it.isTypeScript ? ': whisper.Message' : ''}} = {
       type: whisper.WhisperComponentType.Message,
-      body: this.props.keyboardText,
+      body: keyboardText,
     };
 
-    return [message];
-  }
-
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: KeyboardWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
-
-  close() {
-    this.whisper.close(KeyboardWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Keyboard whisper', err);
-    }
-    console.log('Keyboard whisper closed');
-  }
-}
+    return whisper.create({
+      components: [message],
+      label: 'Keyboard Aptitude Fired',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/NetworkWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/NetworkWhisper.test.ts.squirrelly
@@ -1,5 +1,5 @@
 import { whisper } from '@oliveai/ldk';
-import { NetworkWhisper } from '.';
+import NetworkWhisper, { onClose, createComponents } from './NetworkWhisper';
 
 jest.mock('@oliveai/ldk');
 
@@ -30,9 +30,9 @@ describe('Network Whisper', () => {
     jest.resetAllMocks();
   });
 
-  it('creates components as expected with proper onClick logic', () => {
-    const newWhisper = new NetworkWhisper(TEST_PARAM);
-    const actualComponents = newWhisper.createComponents();
+  it('creates components as expected with proper onClick logic', async () => {
+    const newWhisper = await NetworkWhisper.show(TEST_PARAM);
+    const actualComponents = createComponents(TEST_PARAM);
 
     const expectedComponents = [
       expect.objectContaining({
@@ -47,7 +47,7 @@ describe('Network Whisper', () => {
 
     expect(actualComponents).toEqual(expectedComponents);
 
-    actualComponents[0].onClick();
+    actualComponents[0].onClick?.(undefined, newWhisper{{ it.isTypeScript ? ' as whisper.Whisper' : '' }});
 
     const expectedSubWhisper = {
       label: 'Recall for recalling_firm 1',
@@ -63,15 +63,14 @@ describe('Network Whisper', () => {
   });
 
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = new NetworkWhisper(TEST_PARAM);
-    newWhisper.show();
+    const newWhisper = await NetworkWhisper.show(TEST_PARAM);
     await Promise.resolve();
-    newWhisper.close();
+    newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
         label: 'Example for Network Aptitude (FDA Recalls)',
-        onClose: NetworkWhisper.onClose,
+        onClose,
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -82,7 +81,7 @@ describe('Network Whisper', () => {
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
   `('should close properly $scenario', ({ error }) => {
-    NetworkWhisper.onClose(error);
+    onClose(error);
 
     if (error) {
       expect(console.error).toBeCalledWith('There was an error closing Network whisper', error);

--- a/loop-templates/templates/src/whispers/NetworkWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/NetworkWhisper.ts.squirrelly
@@ -5,81 +5,58 @@ import { stripIndent } from 'common-tags';
 type Recall = {
   [key: string]: string;
 };
-interface Props {
-  recalls: Recall[];
-}
-{{ /if }}
-export default class NetworkWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
 
 {{ /if }}
-  constructor(recalls{{it.isTypeScript ? ': Recall[]' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'Example for Network Aptitude (FDA Recalls)';
-    this.props = {
-      recalls,
-    };
+export const onClose = (err{{ it.isTypeScript ? '?: Error' : '' }}) => {
+  if (err) {
+    console.error('There was an error closing Network whisper', err);
   }
+  console.log('Network whisper closed');
+};
 
-  createComponents() {
-    const components = [];
-    this.props.recalls.forEach((recall) => {
-      components.push({
-        type: whisper.WhisperComponentType.Link,
-        text: `${recall.recalling_firm} (${recall.recall_initiation_date})`,
-        onClick: () => {
-          const markdown = stripIndent`
-          # Recalling Firm
-          ${recall.recalling_firm}
-          # Recall Number
-          ${recall.recall_number}
-          # Product Description
-          ${recall.product_description}
-          # Reason for Recall
-          ${recall.reason_for_recall}
-          `;
+export const createComponents = (recalls{{ it.isTypeScript ? ': Recall[]' : '' }}) => {
+  const components{{ it.isTypeScript ? ': whisper.Link[]' : '' }} = [];
 
-          whisper.create({
-            label: `Recall for ${recall.recalling_firm}`,
-            components: [
-              {
-                type: whisper.WhisperComponentType.Markdown,
-                body: markdown,
-              },
-            ],
-          });
-        },
-      });
+  recalls.forEach((recall) => {
+    components.push({
+      type: whisper.WhisperComponentType.Link,
+      text: `${recall.recalling_firm} (${recall.recall_initiation_date})`,
+      onClick: () => {
+        const markdown = stripIndent`
+        # Recalling Firm
+        ${recall.recalling_firm}
+        # Recall Number
+        ${recall.recall_number}
+        # Product Description
+        ${recall.product_description}
+        # Reason for Recall
+        ${recall.reason_for_recall}
+        `;
+
+        whisper.create({
+          label: `Recall for ${recall.recalling_firm}`,
+          components: [
+            {
+              type: whisper.WhisperComponentType.Markdown,
+              body: markdown,
+            },
+          ],
+        });
+      },
     });
+  });
 
-    return components;
-  }
+  return components;
+};
 
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: NetworkWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
+export default {
+  show: async (recalls{{ it.isTypeScript ? ': Recall[]' : ''}}) => {
+    const components = createComponents(recalls);
 
-  close() {
-    this.whisper.close(NetworkWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Network whisper', err);
-    }
-    console.log('Network whisper closed');
-  }
-}
+    return whisper.create({
+      components,
+      label: 'Example for Network Aptitude (FDA Recalls)',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/UiWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/UiWhisper.ts.squirrelly
@@ -1,56 +1,23 @@
 import { whisper } from '@oliveai/ldk';
 
-{{ @if (it.isTypeScript) }}
-interface Props {
-  searchText: string;
-}
-{{ /if }}
-export default class UiWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
-
-{{ /if }}
-  constructor(searchText{{it.isTypeScript ? ': string' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'UI Search Aptitude Fired';
-    this.props = {
-      searchText,
-    };
+export const onClose = (err{{ it.isTypeScript ? '?: Error' : '' }}) => {
+  if (err) {
+    console.error('There was an error closing UI Search whisper', err);
   }
+  console.log('UI Search whisper closed');
+};
 
-  createComponents() {
-    const message{{it.isTypeScript ? ': whisper.Message' : ''}} = {
+export default {
+  show: async (searchText{{ it.isTypeScript ? ': string' : '' }}) => {
+    const message{{ it.isTypeScript ? ': whisper.Message' : '' }} = {
       type: whisper.WhisperComponentType.Message,
-      body: this.props.searchText,
+      body: searchText,
     };
 
-    return [message];
-  }
-
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: UiWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
-
-  close() {
-    this.whisper.close(UiWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Ui whisper', err);
-    }
-    console.log('Ui whisper closed');
-  }
-}
+    return whisper.create({
+      components: [message],
+      label: 'UI Aptitude Fired',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/WindowWhisper.test.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/WindowWhisper.test.ts.squirrelly
@@ -1,11 +1,11 @@
-import { whisper{{it.isTypeScript ? ', window' : ''}} } from '@oliveai/ldk';
-import { WindowWhisper } from '.';
+import { whisper{{ it.isTypeScript ? ', window' : '' }} } from '@oliveai/ldk';
+import WindowWhisper, { onClose, createComponents } from './WindowWhisper';
 
 jest.mock('@oliveai/ldk');
 
 const mockWhisperClose = jest.fn();
 
-const TEST_PARAM = { path: 'test', pid: 0 }{{it.isTypeScript ? ' as window.WindowInfo' : ''}};
+const TEST_PARAM = { path: 'test', pid: 0 }{{ it.isTypeScript ? ' as window.WindowInfo' : '' }};
 
 describe('Window Whisper', () => {
   beforeEach(() => {
@@ -16,8 +16,7 @@ describe('Window Whisper', () => {
   });
 
   it('creates components as expected', () => {
-    const newWhisper = new WindowWhisper(TEST_PARAM);
-    const actual = newWhisper.createComponents();
+    const actual = createComponents(TEST_PARAM);
 
     const expected = [
       expect.objectContaining({
@@ -36,16 +35,15 @@ describe('Window Whisper', () => {
   });
 
   it('creates a whisper and closes it gracefully', async () => {
-    const newWhisper = new WindowWhisper(TEST_PARAM);
-    newWhisper.show();
+    const newWhisper = await WindowWhisper.show(TEST_PARAM);
     await Promise.resolve();
-    newWhisper.close();
+    newWhisper.close(() => null);
 
     expect(whisper.create).toBeCalledWith(
       expect.objectContaining({
-        components: newWhisper.createComponents(),
+        components: createComponents(TEST_PARAM),
         label: 'Active Window Changed',
-        onClose: WindowWhisper.onClose,
+        onClose,
       })
     );
     expect(mockWhisperClose).toBeCalled();
@@ -56,7 +54,7 @@ describe('Window Whisper', () => {
     ${'without an error'} | ${undefined}
     ${'with an error'}    | ${new Error('error')}
   `('should close properly $scenario', ({ error }) => {
-    WindowWhisper.onClose(error);
+    onClose(error);
 
     if (error) {
       expect(console.error).toBeCalledWith('There was an error closing Window whisper', error);

--- a/loop-templates/templates/src/whispers/WindowWhisper.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/WindowWhisper.ts.squirrelly
@@ -1,65 +1,38 @@
-import { whisper{{it.isTypeScript ? ', window' : ''}} } from '@oliveai/ldk';
+import { whisper{{ it.isTypeScript ? ', window' : '' }} } from '@oliveai/ldk';
 
-{{ @if (it.isTypeScript) }}
-interface Props {
-  activeWindow: window.WindowInfo;
-}
-{{ /if }}
-export default class WindowWhisper {
-{{ @if (it.isTypeScript) }}
-  whisper: whisper.Whisper;
-
-  label: string;
-
-  props: Props;
-
-{{ /if }}
-  constructor(activeWindow{{it.isTypeScript ? ': window.WindowInfo' : ''}}) {
-    this.whisper = undefined;
-    this.label = 'Active Window Changed';
-    this.props = {
-      activeWindow,
-    };
+export const onClose = (err{{ it.isTypeScript ? '?: Error' : '' }}) => {
+  if (err) {
+    console.error('There was an error closing Window whisper', err);
   }
+  console.log('Window whisper closed');
+};
 
-  createComponents() {
-    const name{{it.isTypeScript ? ': whisper.ListPair' : ''}} = {
-      type: whisper.WhisperComponentType.ListPair,
-      copyable: true,
-      label: 'Window Name',
-      value: this.props.activeWindow.path,
-      style: whisper.Urgency.None,
-    };
-    const pid{{it.isTypeScript ? ': whisper.ListPair' : ''}} = {
-      type: whisper.WhisperComponentType.ListPair,
-      copyable: true,
-      label: 'Process Id',
-      value: this.props.activeWindow.pid.toString(),
-      style: whisper.Urgency.None,
-    };
-    return [name, pid];
-  }
+export const createComponents = (activeWindow{{ it.isTypeScript ? ': window.WindowInfo' : '' }}) => {
+  const name{{ it.isTypeScript ? ': whisper.ListPair' : '' }} = {
+    type: whisper.WhisperComponentType.ListPair,
+    copyable: true,
+    label: 'Window Name',
+    value: activeWindow.path,
+    style: whisper.Urgency.None,
+  };
+  const pid{{ it.isTypeScript ? ': whisper.ListPair' : '' }} = {
+    type: whisper.WhisperComponentType.ListPair,
+    copyable: true,
+    label: 'Process Id',
+    value: activeWindow.pid.toString(),
+    style: whisper.Urgency.None,
+  };
+  return [name, pid];
+};
 
-  show() {
-    whisper
-      .create({
-        components: this.createComponents(),
-        label: this.label,
-        onClose: WindowWhisper.onClose,
-      })
-      .then((newWhisper) => {
-        this.whisper = newWhisper;
-      });
-  }
+export default {
+  show: async (activeWindow{{ it.isTypeScript ? ': window.WindowInfo' : '' }}) => {
+    const components = createComponents(activeWindow);
 
-  close() {
-    this.whisper.close(WindowWhisper.onClose);
-  }
-
-  static onClose(err{{it.isTypeScript ? '?: Error' : ''}}) {
-    if (err) {
-      console.error('There was an error closing Window whisper', err);
-    }
-    console.log('Window whisper closed');
-  }
-}
+    return whisper.create({
+      components,
+      label: 'Active Window Changed',
+      onClose,
+    });
+  },
+};

--- a/loop-templates/templates/src/whispers/index.ts
+++ b/loop-templates/templates/src/whispers/index.ts
@@ -5,6 +5,8 @@ import filesystemWhisper from './FilesystemWhisper.ts.squirrelly';
 import index from './index.ts.squirrelly';
 import introWhisperTest from './IntroWhisper.test.ts.squirrelly';
 import introWhisper from './IntroWhisper.ts.squirrelly';
+import introWhisperSimpleTest from './IntroWhisperSimple.test.ts.squirrelly';
+import introWhisperSimple from './IntroWhisperSimple.ts.squirrelly';
 import keyboardWhisperTest from './KeyboardWhisper.test.ts.squirrelly';
 import keyboardWhisper from './KeyboardWhisper.ts.squirrelly';
 import networkWhisperTest from './NetworkWhisper.test.ts.squirrelly';
@@ -23,6 +25,8 @@ const fileMap: FileMap = {
   index: { fileName: 'index.ts', aptitude: 'any' },
   introWhisperTest: { fileName: 'IntroWhisper.test.ts', aptitude: 'any' },
   introWhisper: { fileName: 'IntroWhisper.ts', aptitude: 'any' },
+  introWhisperSimpleTest: { fileName: 'IntroWhisperSimple.test.ts', aptitude: 'any'},
+  introWhisperSimple: { fileName: 'IntroWhisperSimple.ts', aptitude: 'any'},
   keyboardWhisperTest: { fileName: 'KeyboardWhisper.test.ts', aptitude: 'keyboard' },
   keyboardWhisper: { fileName: 'KeyboardWhisper.ts', aptitude: 'keyboard' },
   networkWhisperTest: { fileName: 'NetworkWhisper.test.ts', aptitude: 'network' },
@@ -41,6 +45,8 @@ export default {
   index,
   introWhisperTest,
   introWhisper,
+  introWhisperSimpleTest,
+  introWhisperSimple,
   keyboardWhisperTest,
   keyboardWhisper,
   networkWhisperTest,

--- a/loop-templates/templates/src/whispers/index.ts.squirrelly
+++ b/loop-templates/templates/src/whispers/index.ts.squirrelly
@@ -1,4 +1,5 @@
 import IntroWhisper from './IntroWhisper';
+import IntroWhisperSimple from './IntroWhisperSimple';
 {{ @if (it.aptitudes.includes('clipboard')) }}
 import ClipboardWhisper from './ClipboardWhisper';
 {{ /if }}
@@ -21,6 +22,7 @@ import WindowWhisper from './WindowWhisper';
 {{ @if (it.aptitudes.length) }}
 export {
   IntroWhisper,
+  IntroWhisperSimple,
 {{ @if (it.aptitudes.includes('clipboard')) }}
   ClipboardWhisper,
 {{ /if }}
@@ -41,5 +43,5 @@ export {
 {{ /if }}
 };
 {{ #else }}
-export { IntroWhisper };
+export { IntroWhisper, IntroWhisperSimple };
 {{ /if }}

--- a/loop-templates/templates/tsconfig.json.squirrelly
+++ b/loop-templates/templates/tsconfig.json.squirrelly
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "outDir": "./dist/",
-    "noImplicitAny": false,
-    "module": "es6",
-    "target": "es5",
-    "jsx": "react",
     "allowJs": true,
-    "moduleResolution": "node"
+    "jsx": "react",
+    "module": "es6",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "outDir": "./dist/",
+    "strict": true,
+    "target": "es5"
   }
 }


### PR DESCRIPTION
[HELPS-1385](https://crosschx.atlassian.net/browse/HELPS-1385)

* Updated Whisper, Aptitude, and unit test templates based on loop development findings from the Loopers team
* Updated `tsconfig.json` template to enable strict mode, and updated templates to fix all TypeScript errors that resulted from this change
* Added new `IntroWhisperSimple` Whisper to show the difference between updatable class-based Whispers and simple static Whispers
* Removed unnecessary `collectCoverageFrom` property from `package.json` template