### PR TITLE
HELPS-1900 Rename "Search" to "UI" in VSCode Extension

### DIFF
--- a/create-loop/index.js
+++ b/create-loop/index.js
@@ -120,7 +120,7 @@ const aptitudesPrompt = () => {
       { title: 'Filesystem', value: 'filesystem' },
       { title: 'Keyboard', value: 'keyboard' },
       { title: 'Network', value: 'network' },
-      { title: 'Search', value: 'ui' },
+      { title: 'UI', value: 'ui' },
       { title: 'Window', value: 'window' }
     ],
     hint: 'Use your spacebar to select. You can select multiple!'

--- a/create-loop/package-lock.json
+++ b/create-loop/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/create-loop",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/create-loop/package-lock.json
+++ b/create-loop/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/create-loop",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/create-loop/package.json
+++ b/create-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/create-loop",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Create Olive Helps loops with aptitudes of your choice quickly and easily",
   "main": "index.js",
   "bin": {

--- a/create-loop/package.json
+++ b/create-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oliveai/create-loop",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Create Olive Helps loops with aptitudes of your choice quickly and easily",
   "main": "index.js",
   "bin": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-loop-development-kit",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-loop-development-kit",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Extension to generate boiler plate code for loops",
   "publisher": "Olive-AI",
   "icon": "images/oliveLogo.png",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "engines": {
     "vscode": "^1.54.0"
   },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Extension to generate boiler plate code for loops",
   "publisher": "Olive-AI",
   "icon": "images/oliveLogo.png",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "engines": {
     "vscode": "^1.54.0"
   },

--- a/vscode-extension/src/createLoopForm.html
+++ b/vscode-extension/src/createLoopForm.html
@@ -131,8 +131,8 @@
           </tr>
           <tr>
             <td>
-              <input type="checkbox" id="aptitudesSearch" name="aptitudes" value="ui" />
-              <label for="aptitudesSearch">Search</label>
+              <input type="checkbox" id="aptitudesUI" name="aptitudes" value="ui" />
+              <label for="aptitudesUI">UI</label>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Pretty self-explanatory and simple.

The Jira card mentions renaming any files/vars, but I honestly couldn't find anything. Everything already seems to be organized/setup/named to be for a `ui` aptitude, we just happened to display it as "Search".

The Jira card says we don't need to change the `npx` command, but I did find that the menu labeled the UI aptitude as "Search", so I updated that. Let me know if we don't want this, but I would expect it to be a valid change for this.

Also bumped package versions. Let me know if you'd prefer the minor version be bumped instead.