### PR TITLE
change loop-template to use file path

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Extension to generate boiler plate code for loops",
   "publisher": "Olive-AI",
   "icon": "images/oliveLogo.png",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "engines": {
     "vscode": "^1.67.2"
   },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -68,7 +68,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@oliveai/loop-templates": "^1.0.6",
+    "@oliveai/loop-templates": "../loop-templates",
     "buffer": "^6.0.3",
     "http-browserify": "^1.7.0",
     "https-browserify": "^1.0.0",


### PR DESCRIPTION

Changing to use file-path to follow create-loop standard, will change to npm when repos are split